### PR TITLE
changes to add qSTARS to quicksilver currencies

### DIFF
--- a/cosmos/quicksilver.json
+++ b/cosmos/quicksilver.json
@@ -26,7 +26,12 @@
       "coinDenom": "QCK",
       "coinMinimalDenom": "uqck",
       "coinDecimals": 6
-    }
+    },
+    {
+      "coinDenom:": "qSTARS",
+      "coinMinimalDenom" : "uqstars",
+      "coinDecimals": 6
+  }
   ],
   "feeCurrencies": [
     {


### PR DESCRIPTION
The quicksilver team is onboarding Stargaze zone this week. This PR adds qSTARS to the quicksilver currencies array to display users' qSTARS balance in the extension.