### PR TITLE
changes to add qATOM to quicksilver currency

### DIFF
--- a/cosmos/quicksilver.json
+++ b/cosmos/quicksilver.json
@@ -31,6 +31,11 @@
       "coinDenom": "qSTARS",
       "coinMinimalDenom" : "uqstars",
       "coinDecimals": 6
+    },
+    {
+      "coinDenom": "qATOM",
+      "coinMinimalDenom" : "uqatom",
+      "coinDecimals": 6
     }
   ],
   "feeCurrencies": [


### PR DESCRIPTION
The quicksilver team is onboarding Cosmos zone this week. This PR adds qATOM to the quicksilver currencies array to display users' qATOM balance in the extension.