### PR TITLE
Change minimum gas fee for Umee

### DIFF
--- a/cosmos/umee.json
+++ b/cosmos/umee.json
@@ -34,10 +34,11 @@
       "coinDenom": "UMEE",
       "coinMinimalDenom": "uumee",
       "coinDecimals": 6,
+      "coinGeckoId": "umee",
       "gasPriceStep": {
-        "low": 0.05,
-        "average": 0.06,
-        "high": 0.1
+        "low": 0.06,
+        "average": 0.1,
+        "high": 0.14
       }
     }
   ],


### PR DESCRIPTION
This is in anticipation for umee to raise its minimum gas. Minimum gas on umee will be raised to .06 in the near future. 
