### PR TITLE
Update Dyson Protocol to use Official API/RPC Endpoints

### DIFF
--- a/cosmos/dyson-mainnet.json
+++ b/cosmos/dyson-mainnet.json
@@ -2,14 +2,14 @@
   "chainId": "dyson-mainnet-01",
   "chainName": "Dyson Protocol",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dyson-mainnet/chain.png",
-  "rpc": "https://dyson-rpc.kynraze.com",
-  "rest": "https://dyson-api.kynraze.com",
+  "rpc": "https://rpc.cosmos.directory/dyson",
+  "rest": "https://rest.cosmos.directory/dyson",
   "nodeProvider": {
-        "name": "Kynraze",
-	"email": "support@kynraze.com",
-        "website": "https://kynraze.com"
+        "name": "Dyson Protocol",
+	"email": "dysonprotocol",
+        "website": "https://dysonprotocol.com/"
     },
-  "walletUrlForStaking": "https://explorer.kynraze.com/dyson/staking",
+  "walletUrlForStaking": "https://explorer.dys.dysonprotocol.com/",
   "bip44": {
     "coinType": 118
   },

--- a/cosmos/dyson-mainnet.json
+++ b/cosmos/dyson-mainnet.json
@@ -2,8 +2,8 @@
   "chainId": "dyson-mainnet-01",
   "chainName": "Dyson Protocol",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dyson-mainnet/chain.png",
-  "rpc": "https://rpc.cosmos.directory/dyson",
-  "rest": "https://rest.cosmos.directory/dyson",
+  "rpc": "https://dys-tm.dysonprotocol.com/",
+  "rest": "https://dys-api.dysonprotocol.com/",
   "nodeProvider": {
         "name": "Dyson Protocol",
 	"email": "dysonprotocol@protonmail.com",

--- a/cosmos/dyson-mainnet.json
+++ b/cosmos/dyson-mainnet.json
@@ -34,9 +34,9 @@
       "coinMinimalDenom": "dys",
       "coinDecimals": 0,
       "gasPriceStep": {
-        "low": 0.00008,
-        "average": 0.0001,
-        "high": 0.00025
+        "low": 0.0001,
+        "average": 0.0002,
+        "high": 0.0001
       }
     }
   ],

--- a/cosmos/dyson-mainnet.json
+++ b/cosmos/dyson-mainnet.json
@@ -36,7 +36,7 @@
       "gasPriceStep": {
         "low": 0.0001,
         "average": 0.0002,
-        "high": 0.0001
+        "high": 0.0003
       }
     }
   ],

--- a/cosmos/dyson-mainnet.json
+++ b/cosmos/dyson-mainnet.json
@@ -6,7 +6,7 @@
   "rest": "https://rest.cosmos.directory/dyson",
   "nodeProvider": {
         "name": "Dyson Protocol",
-	"email": "dysonprotocol",
+	"email": "dysonprotocol@protonmail.com",
         "website": "https://dysonprotocol.com/"
     },
   "walletUrlForStaking": "https://explorer.dys.dysonprotocol.com/",


### PR DESCRIPTION
The current api/rpc entries are not official and we're getting reports of errors in Discord. 
This PR updates the Dyson Protocol entry to the main official API provider