### PR TITLE
Add coingecko coin-id for Migaloo chain

### DIFF
--- a/cosmos/migaloo.json
+++ b/cosmos/migaloo.json
@@ -1,51 +1,54 @@
 {
-	"chainId": "migaloo-1",
-	"chainName": "Migaloo",
-    "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/migaloo/chain.png",
-	"rpc": "https://migaloo.rpc.silknodes.io/",
-	"rest": "https://migaloo.api.silknodes.io/",
-    "nodeProvider": {
-    "name": "Silk Nodes",
-    "email": "info@silknodes.io",
-    "website":"https://silknodes.io/"
-  },
-	"bip44": {
-		"coinType": 118
-	},
-	"coinType": 118,
-	"bech32Config": {
-		"bech32PrefixAccAddr": "migaloo",
-		"bech32PrefixAccPub": "migaloopub",
-		"bech32PrefixValAddr": "migaloovaloper",
-		"bech32PrefixValPub": "migaloovaloperpub",
-		"bech32PrefixConsAddr": "migaloovalcons",
-		"bech32PrefixConsPub": "migaloovalconspub"
-	},
-	"currencies": [
-		{
-			"coinDenom": "WHALE",
-			"coinMinimalDenom": "uwhale",
-			"coinDecimals": 6,
-			"coinGeckoId": "unknown"
-		}
-	],
-	"feeCurrencies": [
-		{
-			"coinDenom": "WHALE",
-			"coinMinimalDenom": "uwhale",
-			"coinDecimals": 6,
-			"gasPriceStep": {
-			"low": 0.25,
-			"average": 0.3,
-			"high": 0.35
-		      	}
-		}
-	],
-	"stakeCurrency": {
-		"coinDenom": "WHALE",
-		"coinMinimalDenom": "uwhale",
-		"coinDecimals": 6,
-		"coinGeckoId": "unknown"
-	},
-	"features": ["cosmwasm"]
+   "chainId":"migaloo-1",
+   "chainName":"Migaloo",
+   "chainSymbolImageUrl":"https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/migaloo/chain.png",
+   "rpc":"https://migaloo.rpc.silknodes.io/",
+   "rest":"https://migaloo.api.silknodes.io/",
+   "nodeProvider":{
+      "name":"Silk Nodes",
+      "email":"info@silknodes.io",
+      "website":"https://silknodes.io/"
+   },
+   "bip44":{
+      "coinType":118
+   },
+   "coinType":118,
+   "bech32Config":{
+      "bech32PrefixAccAddr":"migaloo",
+      "bech32PrefixAccPub":"migaloopub",
+      "bech32PrefixValAddr":"migaloovaloper",
+      "bech32PrefixValPub":"migaloovaloperpub",
+      "bech32PrefixConsAddr":"migaloovalcons",
+      "bech32PrefixConsPub":"migaloovalconspub"
+   },
+   "currencies":[
+      {
+         "coinDenom":"WHALE",
+         "coinMinimalDenom":"uwhale",
+         "coinDecimals":6,
+         "coinGeckoId":"white-whale"
+      }
+   ],
+   "feeCurrencies":[
+      {
+         "coinDenom":"WHALE",
+         "coinMinimalDenom":"uwhale",
+         "coinDecimals":6,
+         "coinGeckoId":"white-whale",
+         "gasPriceStep":{
+            "low":0.25,
+            "average":0.3,
+            "high":0.35
+         }
+      }
+   ],
+   "stakeCurrency":{
+      "coinDenom":"WHALE",
+      "coinMinimalDenom":"uwhale",
+      "coinDecimals":6,
+      "coinGeckoId":"white-whale"
+   },
+   "features":[
+      "cosmwasm"
+   ]
 }


### PR DESCRIPTION
The $WHALE token has been listed on [coingecko now](https://www.coingecko.com/en/coins/white-whale), so this PR fixes the coingecko id.