### PR TITLE
Bumped gas fees in atlantic-2 to meet global minimum

### DIFF
--- a/cosmos/atlantic.json
+++ b/cosmos/atlantic.json
@@ -33,9 +33,9 @@
       "coinMinimalDenom": "usei",
       "coinDecimals": 6,
       "gasPriceStep": {
-        "low": 0.01,
-        "average": 0.02,
-        "high": 0.03
+        "low": 3.5,
+        "average": 7,
+        "high": 10.5
       }
     }
   ]


### PR DESCRIPTION
Sei atlantic-2 has a global minimum gas fee of 3.5usei, so this PR is to bump the gas price steps for atlantic-2