### PR TITLE
Add MNTA to Kujira

### DIFF
--- a/cosmos/kaiyo.json
+++ b/cosmos/kaiyo.json
@@ -32,6 +32,12 @@
       "coinMinimalDenom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
       "coinDecimals": 6,
       "coinGeckoId": "usk"
+    },
+     {
+      "coinDenom": "MNTA",
+      "coinMinimalDenom": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
+      "coinDecimals": 6,
+      "coinGeckoId": "mantadao"
     }
   ],
   "feeCurrencies": [


### PR DESCRIPTION
This PR requests to add MNTA as a currency to Kujira. MantaDAO is a swap router and DAO running on the Kujira mainnet.