### PR TITLE
Revert Secret testnet to pulsar-2

### DIFF
--- a/cosmos/pulsar.json
+++ b/cosmos/pulsar.json
@@ -3,10 +3,10 @@
     "name": "Stake Source",
     "email": "taariq@stakesource.network"
   },
-  "rpc": "https://rpc.pulsar3.scrttestnet.com",
-  "rest": "https://api.pulsar3.scrttestnet.com",
-  "chainId": "pulsar-3",
-  "chainName": "Secret Testnet",
+  "rpc": "https://rpc.pulsar.scrttestnet.com",
+  "rest": "https://api.pulsar.scrttestnet.com",
+  "chainId": "pulsar-2",
+  "chainName": "Secret pulsar-2 testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/pulsar/chain.png",
   "stakeCurrency": {
     "coinDenom": "SCRT",


### PR DESCRIPTION
Due to unforseen issues with support for only 1 testnet we have to delay the migration to pulsar-3 for the actively testing dApps.

Please merge when possible.