### PR TITLE
turn on fees stride

### DIFF
--- a/cosmos/stride.json
+++ b/cosmos/stride.json
@@ -100,9 +100,54 @@
       "coinGeckoId": "stride",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/ustrd.png",
       "gasPriceStep": {
-        "low": 0,
-        "average": 0,
-        "high": 0.04
+        "low": 0.0005,
+        "average": 0.005,
+        "high": 0.05
+      }
+    },
+    {
+      "coinDenom": "ATOM",
+      "coinMinimalDenom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "coinDecimals": 6,
+      "coinGeckoId": "cosmos",
+      "gasPriceStep": {
+        "low": 0.0001,
+        "average": 0.001,
+        "high": 0.01
+      }
+    },
+    {
+      "coinDenom": "OSMO",
+      "coinMinimalDenom": "ibc/D24B4564BCD51D3D02D9987D92571EAC5915676A9BD6D9B0C1D0254CB8A5EA34",
+      "coinDecimals": 6,
+      "coinGeckoId": "osmosis",
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/osmosis/uosmo.png",
+      "gasPriceStep": {
+        "low": 0.001,
+        "average": 0.01,
+        "high": 0.1
+      }
+    },
+    {
+      "coinDenom": "stOSMO",
+      "coinMinimalDenom": "stuosmo",
+      "coinDecimals": 6,
+      "coinGeckoId": "osmosis",
+      "gasPriceStep": {
+        "low": 0.001,
+        "average": 0.01,
+        "high": 0.1
+      }
+    },
+    {
+      "coinDenom": "stATOM",
+      "coinMinimalDenom": "stuatom",
+      "coinDecimals": 6,
+      "coinGeckoId": "stride-staked-atom",
+      "gasPriceStep": {
+        "low": 0.0001,
+        "average": 0.001,
+        "high": 0.01
       }
     }
   ],


### PR DESCRIPTION
Stride validators turned on fees as a result of a congested mempool. Fee tokens were specified as follows:

```
minimum-gas-prices = "0.0005ustrd,0.001stuosmo,0.0001stuatom,0.001ibc/D24B4564BCD51D3D02D9987D92571EAC5915676A9BD6D9B0C1D0254CB8A5EA34,0.0001ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
```