### PR TITLE
Update likecoin gas price

### DIFF
--- a/cosmos/likecoin-mainnet.json
+++ b/cosmos/likecoin-mainnet.json
@@ -35,8 +35,8 @@
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/likecoin-mainnet/nanolike.png",
       "gasPriceStep": {
         "low": 1,
-        "average": 2,
-        "high": 3
+        "average": 10,
+        "high": 1000
       }
     }
   ],


### PR DESCRIPTION
min-gas-price of most validators would be at 10nanolike, having levels at 1, 2, 3 causes poor UX