### PR TITLE
Update kava_2222.json - add USDT

### DIFF
--- a/cosmos/kava_2222.json
+++ b/cosmos/kava_2222.json
@@ -73,6 +73,11 @@
       "coinDenom": "XRPB",
       "coinMinimalDenom": "xrpb",
       "coinDecimals": 8
+    },
+    {
+      "coinDenom": "USDT",
+      "coinMinimalDenom": "erc20/tether/usdt",
+      "coinDecimals": 6
     }
   ],
   "feeCurrencies": [


### PR DESCRIPTION
Will this make it so USDT with show up properly under Kava in Keplr wallet? (currently shows as 'erc20/tether/usdt')

I believe this is the denom on the Kava (IBC) side, and not too sure if it's meant to have a different denom on the Kava EVM side....