### PR TITLE
fix typo on stargaze testnet chain id

### DIFF
--- a/cosmos/elgafar.json
+++ b/cosmos/elgafar.json
@@ -1,8 +1,13 @@
 {
   "rpc": "https://rpc.elgafar-1.stargaze-apis.com",
   "rest": "https://rest.elgafar-1.stargaze-apis.com",
-  "chainId": "elfagar-1",
+  "chainId": "elgafar-1",
   "chainName": "Stargaze Testnet",
+  "nodeProvider": {
+    "name": "Stargaze",
+    "email": "admin@stargaze.zone",
+    "website":"https://www.stargaze.zone/"
+  },
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stargaze/chain.png",
   "stakeCurrency": {
     "coinDenom": "STARS",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,7 +45,7 @@ export const nativeTestnetChainIdentifiers: string[] = [
   "atlantic",
   "blockspacerace",
   "mocha",
-  "elfagar",
+  "elgafar",
   "osmo-test",
   "pion",
   "theta-testnet",


### PR DESCRIPTION
- The file name and `testnetId` have typos, which is preventing the website linked to the testnet from running on the emulator. I will leave this PR to fix the problem.
  - https://github.com/cosmos/chain-registry/blob/fa7ae5ff6dc510afdb953d7f7eca5d87040669aa/testnets/stargazetestnet/chain.json#L8

