### PR TITLE
Update bech32Prefix in shentu-2.2.json to shentu

### DIFF
--- a/cosmos/shentu-2.2.json
+++ b/cosmos/shentu-2.2.json
@@ -17,12 +17,12 @@
     "coinType": 118
   },
   "bech32Config": {
-    "bech32PrefixAccAddr": "certik",
-    "bech32PrefixAccPub": "certikpub",
-    "bech32PrefixValAddr": "certikvaloper",
-    "bech32PrefixValPub": "certikvaloperpub",
-    "bech32PrefixConsAddr": "certikvalcons",
-    "bech32PrefixConsPub": "certikvalconspub"
+    "bech32PrefixAccAddr": "shentu",
+    "bech32PrefixAccPub": "shentupub",
+    "bech32PrefixValAddr": "shentuvaloper",
+    "bech32PrefixValPub": "shentuvaloperpub",
+    "bech32PrefixConsAddr": "shentuvalcons",
+    "bech32PrefixConsPub": "shentuvalconspub"
   },
   "currencies": [
     {


### PR DESCRIPTION
Hi Team
Shentu chain changed the prefix to "shentu" in the v2.8.0 upgrade. 

The gov proposals to modify the prefix has been passed：
- [Text proposal ](https://www.mintscan.io/shentu/proposals/22)to change prefix to "shentu".
- [v2.8.0 upgrade proposal](https://www.mintscan.io/shentu/proposals/23).

Release details of v2.8.0: https://github.com/shentufoundation/shentu/releases/tag/v2.8.0