### PR TITLE
Change CUDOS token logo to chain.png

### DIFF
--- a/cosmos/cudos.json
+++ b/cosmos/cudos.json
@@ -28,7 +28,7 @@
 			"coinDenom": "CUDOS",
 			"coinGeckoId": "cudos",
 			"coinMinimalDenom": "acudos",
-			"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/acudos.png"
+			"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/chain.png"
 		}
 	],
 	"feeCurrencies": [
@@ -42,7 +42,7 @@
 				"average": 5000000000000,
 				"high": 6600000000000
 			},
-			"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/acudos.png"
+			"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/chain.png"
 		}
 	],
 	"stakeCurrency": {
@@ -50,7 +50,7 @@
 		"coinDenom": "CUDOS",
 		"coinGeckoId": "cudos",
 		"coinMinimalDenom": "acudos",
-		"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/acudos.png"
+		"coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cudos/chain.png"
 	},
 	"features": [
 		"cosmwasm"


### PR DESCRIPTION
This PR simply changes the reference of the image for the token logo to the chain logo so that they match, as many other chains do. The parralax logo doesn't look as good, so switching it out. Thanks! :)