### PR TITLE
Add MNTA as fee token to Kujira

### DIFF
--- a/cosmos/kaiyo.json
+++ b/cosmos/kaiyo.json
@@ -91,6 +91,12 @@
       "coinDecimals": 6,
       "coinGeckoId": "juno-network"
     },
+      {
+      "coinDenom": "MNTA",
+      "coinMinimalDenom": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
+      "coinDecimals": 6,
+      "coinGeckoId": "mantadao"
+    },
     {
       "coinDenom": "SCRT",
       "coinMinimalDenom": "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",


### PR DESCRIPTION
MNTA is now a popular accepted fee token on Kujira. This PR requests it be added as such for the Keplr dropdown..