### PR TITLE
Add update-currency job in github-actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,3 +56,46 @@ jobs:
           WEBFLOW_TOKEN: ${{ secrets.WEBFLOW_TOKEN }}
           WEBFLOW_COLLECTION_ID: ${{ secrets.WEBFLOW_COLLECTION_ID }}
 
+  update-currency:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Wait for 60 seconds
+        run: sleep 60
+      - name: Extract version from package.json
+        uses: sergeysova/jq-action@v2
+        id: version
+        with:
+          cmd: "jq .currency-updater-version package.json -r"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR Private
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Pull docker image from Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ secrets.CURRENCY_UPDATER_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.version.outputs.value }}
+        run: |
+          docker pull $REGISTRY/$REPOSITORY:$IMAGE_TAG
+      - name: Run docker image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ secrets.CURRENCY_UPDATER_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.version.outputs.value }}
+          ENV: prod
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+        run: |
+          docker run -e ENV=$ENV -e DB_HOST=$DB_HOST -e DB_NAME=$DB_NAME -e DB_USER=$DB_USER -e DB_PASSWORD=$DB_PASSWORD -e DB_PORT=$DB_PORT $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: version
         with:
-          cmd: "jq .currency-updater-version package.json -r"
+          cmd: "jq .currencyUpdaterVersion package.json -r"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainapsis-suggest-chain",
   "version": "0.0.1",
-  "currency-updater-version": "0.0.2",
+  "currencyUpdaterVersion": "0.0.4",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "chainapsis-suggest-chain",
   "version": "0.0.1",
+  "currency-updater-version": "0.0.2",
   "private": true,
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
- The inclusion of sleep 60 takes into account the possibility that the deployed chain-registry url may not have been updated immediately.
- For now, ECR_AWS_ACCESS_KEY_ID/ECR_AWS_SECRET_ACCESS_KEY have been separated, but should permission issues be confirmed, I will fix it to use the original ones.