### PR TITLE
Updates to archway's price of gas to be inline with the minimum price of gas

### DIFF
--- a/cosmos/archway.json
+++ b/cosmos/archway.json
@@ -30,9 +30,9 @@
       "coinGeckoId": "archway",
       "coinMinimalDenom": "aarch",
       "gasPriceStep": {
-        "low": 196000000000,
-        "average": 225400000000,
-        "high": 254800000000
+        "low": 140000000000,
+        "average": 196000000000,
+        "high": 225400000000
       },
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/archway/aarch.png"
     }


### PR DESCRIPTION
The last [PR](https://github.com/chainapsis/keplr-chain-registry/pull/457) was created to give a buffer to the gas price as the initial [PR](https://github.com/chainapsis/keplr-chain-registry/pull/456) caused transactions to fail but the actual issue was that Keplr's node's min price of gas was not adjusted. These nodes have since been updated and therefore I want to update the price to be in line with the network's minimum.