### PR TITLE
Update lum-network.json RPC urls

### DIFF
--- a/cosmos/lum-network.json
+++ b/cosmos/lum-network.json
@@ -1,6 +1,6 @@
 {
-    "rpc": "https://node0.mainnet.lum.network/rpc",
-    "rest": "https://node0.mainnet.lum.network/rest",
+    "rpc": "https://rpc.node0.mainnet.lum.network",
+    "rest": "https://rest.node0.mainnet.lum.network",
     "chainId": "lum-network-1",
     "chainName": "Lum Network",
     "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/lum-network/chain.png",

--- a/cosmos/lum-network.json
+++ b/cosmos/lum-network.json
@@ -13,7 +13,7 @@
     "nodeProvider": {
         "name": "Lum Network",
         "email": "contact@lum.network",
-        "website": "https://lum.network"
+        "website": "https://lum.network/"
     },
     "walletUrlForStaking": "https://wallet.lum.network",
     "bip44": {


### PR DESCRIPTION
### Introduction

This little PR updates the public Lum Network's RPC urls following a recent infrastructure change, to ensure compatibility on Keplr wallet