### PR TITLE
added alt coin type 118 for bitsong

### DIFF
--- a/cosmos/bitsong-2b.json
+++ b/cosmos/bitsong-2b.json
@@ -20,6 +20,11 @@
   "bip44": {
     "coinType": 639
   },
+  "alternativeBIP44s": [
+    {
+      "coinType": 118
+    }
+  ],
   "bech32Config": {
     "bech32PrefixAccAddr": "bitsong",
     "bech32PrefixAccPub": "bitsongpub",


### PR DESCRIPTION
Galaxy Station uses coin type 118 for bitsong