### PR TITLE
Revert "Add evm info for fxcore"

### DIFF
--- a/cosmos/fxcore.json
+++ b/cosmos/fxcore.json
@@ -1,10 +1,6 @@
 {
   "chainId": "fxcore",
   "chainName": "f(x)Core",
-  "evm": {
-    "chainId": 530,
-    "rpc": "https://fx-json-web3.functionx.io:8545"
-  },
   "rpc": "https://fx-json.functionx.io",
   "rest": "https://fx-rest.functionx.io",
   "walletUrl": "https://wallet.keplr.app/chains/fxcore",


### PR DESCRIPTION
Reverts chainapsis/keplr-chain-registry#535

In order to ensure that users can send transactions normally, modifications have to be restored🙏

ref: https://github.com/chainapsis/keplr-wallet/issues/1089