### PR TITLE
added stride private testnet

### DIFF
--- a/cosmos/stride-internal.json
+++ b/cosmos/stride-internal.json
@@ -1,0 +1,60 @@
+{
+  "rpc": "https://stride.testnet-1.stridenet.co",
+  "rest": "https://stride.testnet-1.stridenet.co/api",
+  "chainId": "stride-internal-1",
+  "chainName": "Stride Testnet",
+  "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/chain.png",
+  "stakeCurrency": {
+    "coinDenom": "STRD",
+    "coinMinimalDenom": "ustrd",
+    "coinDecimals": 6,
+    "coinGeckoId": "stride",
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/ustrd.png"
+  },
+  "bip44": {
+    "coinType": 118
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "stride",
+    "bech32PrefixAccPub": "stridepub",
+    "bech32PrefixValAddr": "stridevaloper",
+    "bech32PrefixValPub": "stridevaloperpub",
+    "bech32PrefixConsAddr": "stridevalcons",
+    "bech32PrefixConsPub": "stridevalconspub"
+  },
+  "currencies": [
+    {
+      "coinDenom": "STRD",
+      "coinMinimalDenom": "ustrd",
+      "coinDecimals": 6,
+      "coinGeckoId": "stride",
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/ustrd.png"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "STRD",
+      "coinMinimalDenom": "ustrd",
+      "coinDecimals": 6,
+      "coinGeckoId": "stride",
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/ustrd.png",
+      "gasPriceStep": {
+        "low": 0.0005,
+        "average": 0.005,
+        "high": 0.05
+      }
+    },
+    {
+      "coinDenom": "TIA",
+      "coinMinimalDenom": "ibc/1A7653323C1A9E267FF7BEBF40B3EEA8065E8F069F47F2493ABC3E0B621BF793",
+      "coinDecimals": 6,
+      "coinGeckoId": "celestia",
+      "gasPriceStep": {
+        "low": 0.01,
+        "average": 0.01,
+        "high": 0.01
+      }
+    }
+  ],
+  "features": []
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,4 +56,5 @@ export const nativeTestnetChainIdentifiers: string[] = [
   "test-core",
   "govgen",
   "seda-1-testnet",
+  "stride-internal",
 ];


### PR DESCRIPTION
Running yarn validate throws the following error
```
Invalid image url: https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/chain.png
```
But looking through the code, I don't think is avoidable unless we register a testnet image with the name `stride-internal`, and it seems like other testnets have this error as well so I'm holding that it's a non-issue.