### PR TITLE
Sei Testnet: Update Global Min Gas Price

### DIFF
--- a/cosmos/atlantic.json
+++ b/cosmos/atlantic.json
@@ -33,9 +33,9 @@
       "coinMinimalDenom": "usei",
       "coinDecimals": 6,
       "gasPriceStep": {
-        "low": 0.1,
-        "average": 0.2,
-        "high": 0.3
+        "low": 0.08,
+        "average": 0.1,
+        "high": 0.12
       }
     }
   ]


### PR DESCRIPTION
According to the gas proposal on the Sei chain, the global minimum gas price for atlantic-2 has been bumped to 0.08 in order to even out gas prices between EVM and Cosmos transactions on Sei v2.

See the official Sei chain registry for confirmation of change or the Sei proposals.

https://github.com/sei-protocol/chain-registry/pull/58/files