### PR TITLE
Update Self Chain (SLF) coinImageUrl.

### DIFF
--- a/cosmos/self.json
+++ b/cosmos/self.json
@@ -24,7 +24,8 @@
     {
         "coinDenom": "SLF",
         "coinMinimalDenom": "uslf",
-        "coinDecimals": 6    
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/self/chain.png"
     }
     ],
     "feeCurrencies": [
@@ -32,6 +33,7 @@
         "coinDenom": "SLF",
         "coinMinimalDenom": "uslf",
         "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/self/chain.png",
         "gasPriceStep": {
             "low": 0.005,
             "average": 0.025,
@@ -42,7 +44,8 @@
     "stakeCurrency": {
         "coinDenom": "SLF",
         "coinMinimalDenom": "uslf",
-        "coinDecimals": 6
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/self/chain.png"
     },
     "features": []
 }


### PR DESCRIPTION
Based on the code from Celestia, we have added `coinImageUrl` into the JSON in various locations so that the SLF icon shows properly. Currently, it does not display when added.

![Screenshot 2024-06-17 at 13 49 55](https://github.com/chainapsis/keplr-chain-registry/assets/28684/11a9e6f7-704b-47c3-9ca7-186a760bc1fe)
