### PR TITLE
Change gitopia rpc/rest to managed by public, not native

### DIFF
--- a/cosmos/gitopia.json
+++ b/cosmos/gitopia.json
@@ -2,8 +2,13 @@
   "chainId": "gitopia",
   "chainName": "Gitopia",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gitopia/chain.png",
-  "rpc": "https://rpc-gitopia.keplr.app",
-  "rest": "https://lcd-gitopia.keplr.app",
+  "rpc": "https://gitopia.rpc.kjnodes.com",
+  "rest": "https://gitopia.api.kjnodes.com",
+  "nodeProvider": {
+    "name": "kjnodes",
+    "email": "stake@kjnodes.com",
+    "website": "https://kjnodes.com/"
+  },
   "bip44": {
     "coinType": 118
   },


### PR DESCRIPTION
gitopia is not a keplr native chain anymore, so change rpc/rest to public one.