### PR TITLE
Change gravitybridge rpc/rest to managed by public, not native

### DIFF
--- a/cosmos/gravity-bridge.json
+++ b/cosmos/gravity-bridge.json
@@ -1,6 +1,11 @@
 {
-  "rpc": "https://rpc-gravity-bridge.keplr.app",
-  "rest": "https://lcd-gravity-bridge.keplr.app",
+  "rpc": "https://gravity-rpc.staketab.org/",
+  "rest": "https://gravity-rest.staketab.org",
+  "nodeProvider": {
+    "name": "Staketab",
+    "email": "support@staketab.com",
+    "website": "https://staketab.com/"
+  },
   "chainId": "gravity-bridge-3",
   "chainName": "Gravity Bridge",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gravity-bridge/chain.png",
@@ -11,8 +16,6 @@
     "coinGeckoId": "graviton",
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gravity-bridge/ugraviton.png"
   },
-  "walletUrl": "https://wallet.keplr.app/chains/gravity-bridge",
-  "walletUrlForStaking": "https://wallet.keplr.app/chains/gravity-bridge",
   "bip44": {
     "coinType": 118
   },

--- a/cosmos/gravity-bridge.json
+++ b/cosmos/gravity-bridge.json
@@ -1,5 +1,5 @@
 {
-  "rpc": "https://gravity-rpc.staketab.org/",
+  "rpc": "https://gravity-rpc.staketab.org",
   "rest": "https://gravity-rest.staketab.org",
   "nodeProvider": {
     "name": "Staketab",


### PR DESCRIPTION
gravitybridge is not a keplr native chain anymore, so change rpc/rest to public one.