### PR TITLE
umee: update gas prices to mirror cosmos/chain-registry

### DIFF
--- a/cosmos/umee.json
+++ b/cosmos/umee.json
@@ -41,9 +41,9 @@
       "coinGeckoId": "umee",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/umee/uumee.png",
       "gasPriceStep": {
-        "low": 0.06,
-        "average": 0.1,
-        "high": 0.14
+        "low": 0.1,
+        "average": 0.12,
+        "high": 0.2
       }
     }
   ],


### PR DESCRIPTION
The current low gas setting, specifically, is below the 0.1uumee value that all validators were asked to enforce awhile back, and the sdk reports insufficient fees for borrow / repay transactions.  I'm ambivalent when it comes to updating the average & high settings and have just done so to match the chain-registry repo.  Can omit those changes – just let me know.