### PR TITLE
akash: add gas prices from cosmos/chain-registry

### DIFF
--- a/cosmos/akashnet.json
+++ b/cosmos/akashnet.json
@@ -39,7 +39,12 @@
       "coinMinimalDenom": "uakt",
       "coinDecimals": 6,
       "coinGeckoId": "akash-network",
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/akashnet/uakt.png"
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/akashnet/uakt.png",
+      "gasPriceStep": {
+        "low": 0.00025,
+        "average": 0.0025,
+        "high": 0.025
+      }
     }
   ],
   "features": []


### PR DESCRIPTION
Just as an aside here, Akash is one of a handful of chains where I recently struggle to initiate transactions directly through the wallet.  Stride is another that comes to mind.  I'm checking in the static gas prices from chain-registry here in case it has some UX impact, but perhaps the RPC layer behind `rpc-akash.keplr.app` needs some love?