### PR TITLE
Corrects Sei (EVM) cointype to 118

### DIFF
--- a/evm/eip155:1329.json
+++ b/evm/eip155:1329.json
@@ -9,7 +9,7 @@
   "chainName": "Sei EVM",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/eip155:1329/chain.png",
   "bip44": {
-    "coinType": 60
+    "coinType": 118
   },
   "stakeCurrency": {
     "coinDenom": "SEI",


### PR DESCRIPTION
Update cointype to 118 to align with the cosmos-side cointype. 
In order for interoperability features to work we require the same key to be used to sign for both environments, therefore we must use the same derivation path for each.