### PR TITLE
Add correct Sei cointypes

### DIFF
--- a/cosmos/pacific.json
+++ b/cosmos/pacific.json
@@ -7,6 +7,11 @@
   "bip44": {
     "coinType": 118
   },
+  "alternativeBIP44s": [
+    {
+      "coinType": 60
+    }
+  ],
   "stakeCurrency": {
     "coinDenom": "SEI",
     "coinMinimalDenom": "usei",

--- a/evm/eip155:1329.json
+++ b/evm/eip155:1329.json
@@ -9,8 +9,13 @@
   "chainName": "Sei EVM",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/eip155:1329/chain.png",
   "bip44": {
-    "coinType": 60
+    "coinType": 118
   },
+  "alternativeBIP44s": [
+    {
+      "coinType": 60
+    }
+  ],
   "stakeCurrency": {
     "coinDenom": "SEI",
     "coinMinimalDenom": "sei-native",


### PR DESCRIPTION
As dicussed here (https://github.com/chainapsis/keplr-chain-registry/pull/818), we're submitting this PR with some changes made: 

Both Sei EVM and Sei Cosmos both get Cointype 60 and Cointype 118 set as supported, with cointype 118 set as main and cointype 60 as an additionally supported cointype. 