### PR TITLE
Change mars protocol endpoints to publicnode

### DIFF
--- a/cosmos/mars.json
+++ b/cosmos/mars.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://rpc-mars.keplr.app",
-  "rest": "https://lcd-mars.keplr.app",
+  "rpc": "https://mars-rpc.publicnode.com",
+  "rest": "https://mars-rest.publicnode.com",
   "chainId": "mars-1",
   "chainName": "Mars Hub",
   "stakeCurrency": {


### PR DESCRIPTION
- use more stable endpoinst for users undelegate their assets without any problems before mars protocol support ends
- https://mars-rpc.publicnode.com/