### PR TITLE
Search chains by stake currency or main currency denom on server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import fs from "fs/promises";
 import { ChainInfo } from "@keplr-wallet/types";
 
 type SearchOption = "all" | "cosmos" | "evm";
-type FilterOption = "all" | "chain" | "token";
+type FilterOption = "all" | "chain" | "token" | "chainNameAndToken";
 
 let allChains: ChainInfo[] | undefined;
 let cosmosChainInfos: ChainInfo[] | undefined;
@@ -105,6 +105,10 @@ const filterChains = (
         return chainName.includes(searchText) || chainId.includes(searchText);
       case "token":
         return tokenDenom.includes(searchText);
+      case "chainNameAndToken":
+        return (
+          chainName.includes(searchText) || tokenDenom.includes(searchText)
+        );
       default:
         return false;
     }


### PR DESCRIPTION
- 익스텐션에서 요청을 보내 체인을 검색할 때, 체인 정보에서 모든 currencies의 denom을 가져와 검색어가 포함된 체인을 반환하게 되면 너무나도 많은 체인이 한번에 반환되므로, 다음과 같이 각 체인별로 사용할 denom을 제한합니다.
  - cosmos: stakeCurrency의 denom을 사용. stakeCurrency가 없는 경우, currencies의 첫번째 항목의 denom을 사용.
  - ethereum: currencies의 첫번째 항목의 denom을 사용. (일반적으로 ETH 또는 체인의 main currency)
- 또한 필터링 옵션으로 `chainNameAndToken`을 추가하여 체인 이름 및 제한된 자산 denom과 매칭되는 체인 리스트만 보여줍니다.

| tony approved