### PR TITLE
add zenrock imageurl

### DIFF
--- a/cosmos/diamond.json
+++ b/cosmos/diamond.json
@@ -1,49 +1,55 @@
 {
-    "chainId": "diamond-1",
-    "chainName": "Zenrock",
-    "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/diamond/chain.png",
-    "rpc": "https://rpc.diamond.zenrocklabs.io",
-    "rest": "https://api.diamond.zenrocklabs.io",
-    "nodeProvider": {
-      "name": "Zenrock",
-      "discord": "https://discord.gg/zenrockfoundation",
-      "email": "support@zenrocklabs.io",
-      "website": "https://zenrocklabs.io/"
-    },
-    "bip44": {
-      "coinType": 118
-    },
-    "bech32Config": {
-      "bech32PrefixAccAddr": "zen",
-      "bech32PrefixAccPub": "zenpub",
-      "bech32PrefixValAddr": "zenvaloper",
-      "bech32PrefixValPub": "zenvaloperpub",
-      "bech32PrefixConsAddr": "zenvalcons",
-      "bech32PrefixConsPub": "zenvalconspub"
-    },
-    "currencies": [
-      {
-        "coinDenom": "ROCK",
-        "coinMinimalDenom": "urock",
-        "coinDecimals": 6
-      }
-    ],
-    "feeCurrencies": [
-      {
-        "coinDenom": "ROCK",
-        "coinMinimalDenom": "urock",
-        "coinDecimals": 6,
-        "gasPriceStep": {
-          "low": 0.5,
-          "average": 0.55,
-          "high": 0.6
-        }
-      }
-    ],
-    "stakeCurrency": {
+  "chainId": "diamond-1",
+  "chainName": "Zenrock",
+  "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/diamond/chain.png",
+  "rpc": "https://rpc.diamond.zenrocklabs.io",
+  "rest": "https://api.diamond.zenrocklabs.io",
+  "nodeProvider": {
+    "name": "Zenrock",
+    "discord": "https://discord.gg/zenrockfoundation",
+    "email": "support@zenrocklabs.io",
+    "website": "https://zenrocklabs.io/"
+  },
+  "bip44": {
+    "coinType": 118
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "zen",
+    "bech32PrefixAccPub": "zenpub",
+    "bech32PrefixValAddr": "zenvaloper",
+    "bech32PrefixValPub": "zenvaloperpub",
+    "bech32PrefixConsAddr": "zenvalcons",
+    "bech32PrefixConsPub": "zenvalconspub"
+  },
+  "currencies": [
+    {
       "coinDenom": "ROCK",
       "coinMinimalDenom": "urock",
-      "coinDecimals": 6
-    },
-    "features": ["cosmwasm"]
-  }
+      "coinDecimals": 6,
+      "coinGeckoId": "zenrock",
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/diamond/chain.png"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "ROCK",
+      "coinMinimalDenom": "urock",
+      "coinDecimals": 6,
+      "coinGeckoId": "zenrock",
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/diamond/chain.png",
+      "gasPriceStep": {
+        "low": 0.5,
+        "average": 0.55,
+        "high": 0.6
+      }
+    }
+  ],
+  "stakeCurrency": {
+    "coinDenom": "ROCK",
+    "coinMinimalDenom": "urock",
+    "coinDecimals": 6,
+    "coinGeckoId": "zenrock",
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/diamond/chain.png"
+  },
+  "features": ["cosmwasm"]
+}

--- a/cosmos/gardia.json
+++ b/cosmos/gardia.json
@@ -1,49 +1,52 @@
 {
-    "chainId": "gardia-2",
-    "chainName": "Gardia Testnet",
-    "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png",
-    "rpc": "https://rpc.gardia.zenrocklabs.io",
-    "rest": "https://api.gardia.zenrocklabs.io",
-    "nodeProvider": {
-      "name": "Zenrock",
-      "discord": "https://discord.gg/zenrockfoundation",
-      "email": "support@zenrocklabs.io",
-      "website": "https://zenrocklabs.io/"
-    },
-    "bip44": {
-      "coinType": 118
-    },
-    "bech32Config": {
-      "bech32PrefixAccAddr": "zen",
-      "bech32PrefixAccPub": "zenpub",
-      "bech32PrefixValAddr": "zenvaloper",
-      "bech32PrefixValPub": "zenvaloperpub",
-      "bech32PrefixConsAddr": "zenvalcons",
-      "bech32PrefixConsPub": "zenvalconspub"
-    },
-    "currencies": [
-      {
-        "coinDenom": "ROCK",
-        "coinMinimalDenom": "urock",
-        "coinDecimals": 6
-      }
-    ],
-    "feeCurrencies": [
-      {
-        "coinDenom": "ROCK",
-        "coinMinimalDenom": "urock",
-        "coinDecimals": 6,
-        "gasPriceStep": {
-          "low": 0.5,
-          "average": 0.55,
-          "high": 0.6
-        }
-      }
-    ],
-    "stakeCurrency": {
+  "chainId": "gardia-2",
+  "chainName": "Gardia Testnet",
+  "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png",
+  "rpc": "https://rpc.gardia.zenrocklabs.io",
+  "rest": "https://api.gardia.zenrocklabs.io",
+  "nodeProvider": {
+    "name": "Zenrock",
+    "discord": "https://discord.gg/zenrockfoundation",
+    "email": "support@zenrocklabs.io",
+    "website": "https://zenrocklabs.io/"
+  },
+  "bip44": {
+    "coinType": 118
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "zen",
+    "bech32PrefixAccPub": "zenpub",
+    "bech32PrefixValAddr": "zenvaloper",
+    "bech32PrefixValPub": "zenvaloperpub",
+    "bech32PrefixConsAddr": "zenvalcons",
+    "bech32PrefixConsPub": "zenvalconspub"
+  },
+  "currencies": [
+    {
       "coinDenom": "ROCK",
       "coinMinimalDenom": "urock",
-      "coinDecimals": 6
-    },
-    "features": ["cosmwasm"]
-  }
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "ROCK",
+      "coinMinimalDenom": "urock",
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png",
+      "gasPriceStep": {
+        "low": 0.5,
+        "average": 0.55,
+        "high": 0.6
+      }
+    }
+  ],
+  "stakeCurrency": {
+    "coinDenom": "ROCK",
+    "coinMinimalDenom": "urock",
+    "coinDecimals": 6,
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png"
+  },
+  "features": ["cosmwasm"]
+}


### PR DESCRIPTION
This PR updates the imageurls for `gardia.json` and `zenrock.json` and adds the coingeckoId for mainnet