### PR TITLE
Changes Sei bip44 Cointype to 60 for Cosmos+EVM environments, adding 118 as alternate.

### DIFF
--- a/cosmos/pacific.json
+++ b/cosmos/pacific.json
@@ -5,8 +5,13 @@
   "chainName": "Sei",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/pacific/chain.png",
   "bip44": {
-    "coinType": 118
+    "coinType": 60
   },
+  "alternativeBIP44s": [
+    {
+      "coinType": 118
+    }
+  ],
   "stakeCurrency": {
     "coinDenom": "SEI",
     "coinMinimalDenom": "usei",

--- a/evm/eip155:1329.json
+++ b/evm/eip155:1329.json
@@ -11,6 +11,11 @@
   "bip44": {
     "coinType": 60
   },
+  "alternativeBIP44s": [
+    {
+      "coinType": 118
+    }
+  ],
   "stakeCurrency": {
     "coinDenom": "SEI",
     "coinMinimalDenom": "sei-native",


### PR DESCRIPTION
The changes here are explained in great detail in [keplr-wallet issue #1261](https://github.com/chainapsis/keplr-wallet/issues/1261).

I fully realize that there is no ideal solution to this issue, but this is the lesser of all evils in both UX and devex as well as for the foreseeable future.

Having cointype 60 as the primary with 118 as a valid alternative:
 - Aligns with EVM standards
 - Aligns with the pending Ledger Sei application which also uses cointype 60 for both signers
 - Does not further break compatibility with either Squidouter or Skip swaps since they already require that users manually enter their address for this network due to related interoperability issues
 - Allows all existing users to access their funds across both environments as intended within the Sei network
 - Ensures new wallets are created under the intended "canonical" cointype 60 across the network