### PR TITLE
update gardia chain-id

### DIFF
--- a/cosmos/gardia.json
+++ b/cosmos/gardia.json
@@ -1,6 +1,6 @@
 {
-  "chainId": "gardia-2",
-  "chainName": "Gardia Testnet",
+  "chainId": "gardia-3",
+  "chainName": "Zenrock Gardia Testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png",
   "rpc": "https://rpc.gardia.zenrocklabs.io",
   "rest": "https://api.gardia.zenrocklabs.io",


### PR DESCRIPTION
This PR updates gardia's chain-id from `gardia-2` to `gardia-3`.