### PR TITLE
chore: Update gas price steps for CHEQ

### DIFF
--- a/cosmos/cheqd-mainnet.json
+++ b/cosmos/cheqd-mainnet.json
@@ -36,9 +36,9 @@
       "coinDecimals": 9,
       "coinGeckoId": "cheqd-network",
       "gasPriceStep": {
-        "low": 25,
-        "average": 50,
-        "high": 100
+        "low": 5000,
+        "average": 7500,
+        "high": 10000
       }
     }
   ],


### PR DESCRIPTION
This minor change updates the [suggested static gas prices to the new values recommended](https://docs.cheqd.io/node/getting-started/cheqd-cli/cheqd-cli-token-transactions#suggested-static-gas-price-values) by the CHEQ network