### PR TITLE
chore: update manifest testnet chain name

### DIFF
--- a/cosmos/manifest-ledger-testnet.json
+++ b/cosmos/manifest-ledger-testnet.json
@@ -1,6 +1,6 @@
 {
     "chainId": "manifest-ledger-testnet",
-    "chainName": "Manifest",
+    "chainName": "Manifest Testnet",
     "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/manifest-ledger-testnet/chain.png",
     "rpc": "https://nodes.liftedinit.tech/manifest/testnet/rpc",
     "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",


### PR DESCRIPTION
This PR updates the Manifest Testnet chain name to include `Testnet`.