### PR TITLE
chore:adds alpha keyword for alpha testnet

### DIFF
--- a/cosmos/qubetics_9003.json
+++ b/cosmos/qubetics_9003.json
@@ -2,7 +2,7 @@
     "rpc": "https://alphatestnet-rpc.qubetics.work/",
     "rest": "https://alphatestnet-swagger.qubetics.work/",
     "chainId": "qubetics_9003-1",
-    "chainName": "Qubetics-Testnet",
+    "chainName": "Qubetics-AlphaTestnet",
     "evm": {
       "chainId": 9003,
       "rpc": "https://alphatestnet-evm-rpc.qubetics.work"


### PR DESCRIPTION
This PR renames the chain to qubetics alpha testnet to maintain clear distinction between the  testnets.