### PR TITLE
Fix Nillion fee rates

### DIFF
--- a/cosmos/nillion.json
+++ b/cosmos/nillion.json
@@ -40,9 +40,9 @@
       "coinDecimals": 6,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/nillion/nil.png",
       "gasPriceStep": {
-        "low": 0.025,
-        "average": 0.025,
-        "high": 0.1
+        "low": 0.0001,
+        "average": 0.0001,
+        "high": 0.00025
       }
     }
   ],


### PR DESCRIPTION
Fix Nillion fee rates

Updated to [match the chain registry](https://github.com/cosmos/chain-registry/blob/master/nillion/chain.json#L18-L20). Tested these new, much lower fee rates from Osmosis Zone, which otherwise succeeds, but upon choosing any fee tier in Keplr (overriding the fee set by Osmosis Zone), a (Max) Deposit becomes impossible due to insufficient fees.