### PR TITLE
[feat] add walletUrlForStaking on neutron

### DIFF
--- a/cosmos/neutron.json
+++ b/cosmos/neutron.json
@@ -7,6 +7,7 @@
   "bip44": {
     "coinType": 118
   },
+  "walletUrlForStaking": "https://wallet.keplr.app/chains/neutron",
   "bech32Config": {
     "bech32PrefixAccAddr": "neutron",
     "bech32PrefixAccPub": "neutronpub",
@@ -246,7 +247,5 @@
       }
     }
   ],
-  "features": [
-    "cosmwasm"
-  ]
+  "features": ["cosmwasm"]
 }

--- a/cosmos/neutron.json
+++ b/cosmos/neutron.json
@@ -16,6 +16,13 @@
     "bech32PrefixConsAddr": "neutronvalcons",
     "bech32PrefixConsPub": "neutronvalconspub"
   },
+  "stakeCurrency": {
+    "coinDenom": "NTRN",
+    "coinMinimalDenom": "untrn",
+    "coinDecimals": 6,
+    "coinGeckoId": "neutron-3",
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/neutron/untrn.png"
+  },
   "currencies": [
     {
       "coinDenom": "NTRN",

--- a/cosmos/pion.json
+++ b/cosmos/pion.json
@@ -7,6 +7,7 @@
   "bip44": {
     "coinType": 118
   },
+  "walletUrlForStaking": "https://wallet.keplr.app/chains/neutron",
   "stakeCurrency": {
     "coinDenom": "NTRN",
     "coinMinimalDenom": "untrn",

--- a/cosmos/pion.json
+++ b/cosmos/pion.json
@@ -7,7 +7,6 @@
   "bip44": {
     "coinType": 118
   },
-  "walletUrlForStaking": "https://wallet.keplr.app/chains/neutron",
   "stakeCurrency": {
     "coinDenom": "NTRN",
     "coinMinimalDenom": "untrn",


### PR DESCRIPTION
walletUrlForStaking를 neutron에 추가했습니다.
실제 뉴트론 업그레이드 이후 staking 모듈이 뉴트론에 생겼을때 해당 pr이 머지되어야 합니다.