### PR TITLE
fix: update XRPL EVM Testnet chain name in registry

### DIFF
--- a/cosmos/xrplevm_1449000.json
+++ b/cosmos/xrplevm_1449000.json
@@ -2,7 +2,7 @@
     "rpc": "https://rpc.xrpl.cumulo.com.es/",
     "rest": "https://api.xrpl.cumulo.com.es/",
     "chainId": "xrplevm_1449000-1",
-    "chainName": "XRPLEVM Testnet",
+    "chainName": "XRPL EVM Testnet",
     "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/xrplevm_1449000/chain.png",
     "bip44": {
       "coinType": 118
@@ -24,7 +24,6 @@
       {
         "coinDenom": "XRP",
         "coinMinimalDenom": "axrp",
-        "coinGeckoId": "ripple",
         "coinDecimals": 18,
         "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/xrplevm_1449000/xrp-logo.png"
       }
@@ -33,7 +32,6 @@
       {
         "coinDenom": "XRP",
         "coinMinimalDenom": "axrp",
-        "coinGeckoId": "ripple",
         "coinDecimals": 18,
         "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/xrplevm_1449000/xrp-logo.png",
         "gasPriceStep": {


### PR DESCRIPTION
## Description

This PR corrects the naming of the testnet chain in the registry file. The chain name was previously listed as "XRPLEVM Testnet" and has been updated to "XRPL EVM Testnet" to reflect the proper naming convention.

## Changes

- Updated `chainName` in `cosmos/xrplevm_1449000.json` from "XRPLEVM Testnet" to "XRPL EVM Testnet".
- Removed any duplicate or erroneous entries related to the chain name.
- Delete coinGeckoId currency and currency fee so it does not show a $ value.

## Rationale

Accurate chain naming ensures that the testnet is correctly identified by developers and users. This change helps maintain consistency across our documentation and configuration, reducing any potential confusion.

## Testing

- Verify that the JSON file displays the correct chain name.
- Ensure that any tools or scripts which rely on the chain name are not adversely affected by this change.

---

Allow maintainers to edit this message if further adjustments are necessary. Contributions to this repository are subject to our GitHub Community Guidelines.
