### PR TITLE
Update seda testnet gas fee tiers

### DIFF
--- a/cosmos/seda-1-testnet.json
+++ b/cosmos/seda-1-testnet.json
@@ -33,7 +33,12 @@
       "coinDenom": "SEDA",
       "coinMinimalDenom": "aseda",
       "coinDecimals": 18,
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/seda-1-testnet/chain.png"
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/seda-1-testnet/chain.png",
+      "gasPriceStep": {
+        "low": 10000000000,
+        "average": 15000000000,
+        "high": 20000000000
+      }
     }
   ],
   "stakeCurrency": {


### PR DESCRIPTION
This PR updates the gasPriceStep values for the SEDA testnet in the Keplr chain registry to match those used in the SEDA mainnet for consistency.