### PR TITLE
bump: gardia chain-id

### DIFF
--- a/cosmos/gardia.json
+++ b/cosmos/gardia.json
@@ -1,5 +1,5 @@
 {
-  "chainId": "gardia-4",
+  "chainId": "gardia-5",
   "chainName": "Zenrock Gardia Testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gardia/chain.png",
   "rpc": "https://rpc.gardia.zenrocklabs.io",


### PR DESCRIPTION
This PR bumps the zenrock gardia chain id from `gardia-4` to `gardia-5`.