### PR TITLE
AtomeOne PHOTON fee priority

### DIFF
--- a/cosmos/atomone-testnet.json
+++ b/cosmos/atomone-testnet.json
@@ -36,17 +36,6 @@
   ],
   "feeCurrencies": [
     {
-      "coinDenom": "ATONE",
-      "coinMinimalDenom": "uatone",
-      "coinDecimals": 6,
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/atomone-testnet/atone.png",
-      "gasPriceStep": {
-        "low": 0.025,
-        "average": 0.04,
-        "high": 0.08
-      }
-    },
-    {
       "coinDenom": "PHOTON",
       "coinMinimalDenom": "uphoton",
       "coinDecimals": 6,
@@ -55,6 +44,17 @@
         "low": 0.225,
         "average": 0.36,
         "high": 0.72
+      }
+    },
+    {
+      "coinDenom": "ATONE",
+      "coinMinimalDenom": "uatone",
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/atomone-testnet/atone.png",
+      "gasPriceStep": {
+        "low": 0.025,
+        "average": 0.04,
+        "high": 0.08
       }
     }
   ],

--- a/cosmos/atomone.json
+++ b/cosmos/atomone.json
@@ -33,6 +33,17 @@
   ],
   "feeCurrencies": [
     {
+      "coinDenom": "PHOTON",
+      "coinMinimalDenom": "uphoton",
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/atomone/photon.png",
+      "gasPriceStep": {
+        "low": 0.225,
+        "average": 0.36,
+        "high": 0.72
+      }
+    },
+    {
       "coinDenom": "ATONE",
       "coinMinimalDenom": "uatone",
       "coinDecimals": 6,
@@ -42,17 +53,6 @@
         "low": 0.025,
         "average": 0.04,
         "high": 0.08
-      }
-    },
-    {
-      "coinDenom": "PHOTON",
-      "coinMinimalDenom": "uphoton",
-      "coinDecimals": 6,
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/atomone/photon.png",
-      "gasPriceStep": {
-        "low": 0.225,
-        "average": 0.36,
-        "high": 0.72
       }
     }
   ],


### PR DESCRIPTION
Move PHOTON to the first position in the `feeCurrencies` array so that it is suggested first.