### PR TITLE
fix: update coinMinimalDenoms for Thorchain app-layer tokens

### DIFF
--- a/cosmos/thorchain.json
+++ b/cosmos/thorchain.json
@@ -31,27 +31,27 @@
     },
     {
       "coinDenom": "RUJI",
-      "coinMinimalDenom": "ruji",
+      "coinMinimalDenom": "x/ruji",
       "coinDecimals": 8,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/thorchain/ruji.png"
     },
     {
       "coinDenom": "NAMI",
-      "coinMinimalDenom": "nami",
+      "coinMinimalDenom": "thor.nami",
       "coinDecimals": 8,
       "coinGeckoId": "nami-protocol",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/thorchain/nami.png"
     },
     {
       "coinDenom": "LQDY",
-      "coinMinimalDenom": "lqdy",
+      "coinMinimalDenom": "thor.lqdy",
       "coinDecimals": 8,
       "coinGeckoId": "mantadao",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/thorchain/lqdy.png"
     },
     {
       "coinDenom": "AUTO",
-      "coinMinimalDenom": "auto",
+      "coinMinimalDenom": "thor.auto",
       "coinDecimals": 8,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/thorchain/auto.png"
     }
@@ -70,5 +70,7 @@
       }
     }
   ],
-  "features": ["cosmwasm"]
+  "features": [
+    "cosmwasm"
+  ]
 }


### PR DESCRIPTION
## Summary
This PR fixes the token denominations for the new app-layer tokens on Thorchain. Incorrect denominations were causing these tokens not to appear in Keplr.

## Details
- Updates the `coinMinimalDenoms` for the following tokens: `thor.nami`, `thor.lqdy`, `thor.auto`, and `x/ruji`.
- The incorrect denominations prevented proper display and integration in wallets like Keplr.

## Verification
You can verify the correct denominations by running:
```sh
thornode query bank total-supply --node https://rpc.ninerealms.com
```
You should see output similar to:
```sh
- amount: "5647240883825800"
  denom: thor.nami
- amount: "101839819512800"
  denom: thor.lqdy
- amount: "1581613991529600"
  denom: thor.auto
- amount: "10000000000000000"
  denom: x/ruji
```
