### PR TITLE
chore: update manifest email and add mfx coingecko id

### DIFF
--- a/cosmos/manifest-ledger-mainnet.json
+++ b/cosmos/manifest-ledger-mainnet.json
@@ -6,7 +6,7 @@
     "rest": "https://nodes.liftedinit.app/manifest/api",
     "nodeProvider": {
       "name": "The Lifted Initiative",
-      "email": "infra@liftedinit.org",
+      "email": "hello@manifest.network",
       "website": "https://manifestai.org/"
     },
     "bip44": {
@@ -24,7 +24,8 @@
       {
         "coinDenom": "MFX",
         "coinMinimalDenom": "umfx",
-        "coinDecimals": 6
+        "coinDecimals": 6,
+        "coinGeckoId": "manifest-2"
       },
       {
         "coinDenom": "POA",
@@ -37,6 +38,7 @@
         "coinDenom": "MFX",
         "coinMinimalDenom": "umfx",
         "coinDecimals": 6,
+        "coinGeckoId": "manifest-2",
         "gasPriceStep": {
           "low": 1.05,
           "average": 1.1,

--- a/cosmos/manifest-ledger-testnet.json
+++ b/cosmos/manifest-ledger-testnet.json
@@ -6,7 +6,7 @@
     "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",
     "nodeProvider": {
       "name": "The Lifted Initiative",
-      "email": "infra@liftedinit.org",
+      "email": "hello@manifest.network",
       "website": "https://manifestai.org/"
     },
     "bip44": {


### PR DESCRIPTION
This pull request updates the configuration files for both the mainnet and testnet of the Manifest Ledger network. The changes include updating contact information, adding a `coinGeckoId` for better integration with external services, and ensuring consistency across the configurations.

### Updates to contact information:
* Updated the `email` field for the node provider from `infra@liftedinit.org` to `hello@manifest.network` in both `cosmos/manifest-ledger-mainnet.json` and `cosmos/manifest-ledger-testnet.json`. [[1]](diffhunk://#diff-d33db0ce7aa545bab439cd47b0477ea6216006333a76748158582ff9bbd1701dL9-R9) [[2]](diffhunk://#diff-6419de1671d356ad14c0d2fbe47cbe0bfa9284457f78f69c6d4db6011501dadcL9-R9)

### Enhancements for external integrations:
* Added the `coinGeckoId` field with the value `"manifest-2"` to the `MFX` coin configuration in `cosmos/manifest-ledger-mainnet.json`. [[1]](diffhunk://#diff-d33db0ce7aa545bab439cd47b0477ea6216006333a76748158582ff9bbd1701dL27-R28) [[2]](diffhunk://#diff-d33db0ce7aa545bab439cd47b0477ea6216006333a76748158582ff9bbd1701dR41)