### PR TITLE
chore: update manifest email

### DIFF
--- a/cosmos/manifest-ledger-mainnet.json
+++ b/cosmos/manifest-ledger-mainnet.json
@@ -6,7 +6,7 @@
     "rest": "https://nodes.liftedinit.app/manifest/api",
     "nodeProvider": {
       "name": "The Lifted Initiative",
-      "email": "infra@liftedinit.org",
+      "email": "hello@manifest.network",
       "website": "https://manifestai.org/"
     },
     "bip44": {

--- a/cosmos/manifest-ledger-testnet.json
+++ b/cosmos/manifest-ledger-testnet.json
@@ -6,7 +6,7 @@
     "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",
     "nodeProvider": {
       "name": "The Lifted Initiative",
-      "email": "infra@liftedinit.org",
+      "email": "hello@manifest.network",
       "website": "https://manifestai.org/"
     },
     "bip44": {


### PR DESCRIPTION
This pull request updates contact information for the node provider in both the mainnet and testnet configuration files for the Manifest Ledger. The email address has been changed to reflect the new contact domain.

Changes to contact information:

* [`cosmos/manifest-ledger-mainnet.json`](diffhunk://#diff-d33db0ce7aa545bab439cd47b0477ea6216006333a76748158582ff9bbd1701dL9-R9): Updated the node provider's email address from `infra@liftedinit.org` to `hello@manifest.network`.
* [`cosmos/manifest-ledger-testnet.json`](diffhunk://#diff-6419de1671d356ad14c0d2fbe47cbe0bfa9284457f78f69c6d4db6011501dadcL9-R9): Updated the node provider's email address from `infra@liftedinit.org` to `hello@manifest.network`.