### PR TITLE
Update Initia, dydx testnet RPC/LCD endpoints

### DIFF
--- a/cosmos/dydx-testnet.json
+++ b/cosmos/dydx-testnet.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://rpc-dydx-testnet.keplr.app",
-  "rest": "https://lcd-dydx-testnet.keplr.app",
+  "rpc": "https://test-dydx-rpc.kingnodes.com",
+  "rest": "https://test-dydx-rest.kingnodes.com",
   "chainId": "dydx-testnet-4",
   "chainName": "dydx Testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dydx-testnet/chain.png",

--- a/cosmos/initiation.json
+++ b/cosmos/initiation.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://rpc-initia-testnet.keplr.app",
-  "rest": "https://lcd-initia-testnet.keplr.app",
+  "rpc": "https://initia-testnet.rpc.kjnodes.com",
+  "rest": "https://initia-testnet.api.kjnodes.com",
   "chainId": "initiation-2",
   "chainName": "Initia Testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/initiation/chain.png",


### PR DESCRIPTION
Since the testnet nodes are being removed, the RPC/LCD endpoints must be updated to use external ones.

Target : initia testnet, dydx testnet