### PR TITLE
chore(union-testnet-10): update union info for v1.2.0

### DIFF
--- a/cosmos/union-testnet.json
+++ b/cosmos/union-testnet.json
@@ -22,29 +22,29 @@
   },
   "currencies": [
     {
-      "coinDenom": "UNO",
-      "coinMinimalDenom": "muno",
-      "coinDecimals": 6,
+      "coinDenom": "U",
+      "coinMinimalDenom": "au",
+      "coinDecimals": 18,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union-testnet/chain.png"
     }
   ],
   "feeCurrencies": [
     {
-      "coinDenom": "UNO",
-      "coinMinimalDenom": "muno",
-      "coinDecimals": 6,
+      "coinDenom": "U",
+      "coinMinimalDenom": "au",
+      "coinDecimals": 18,
       "gasPriceStep": {
-        "low": 0.0025,
-        "average": 0.025,
-        "high": 0.04
+        "low": 1,
+        "average": 1,
+        "high": 2
       },
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union-testnet/chain.png"
     }
   ],
   "stakeCurrency": {
-    "coinDenom": "UNO",
-    "coinMinimalDenom": "muno",
-    "coinDecimals": 6,
+    "coinDenom": "U",
+    "coinMinimalDenom": "au",
+    "coinDecimals": 18,
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union-testnet/chain.png"
   },
   "features": ["cosmwasm"],


### PR DESCRIPTION
Updates `union-testnet-10` chain info to be accurate as of Union v1.2.0