### PR TITLE
Add PRYZM token to the fee currencies of Pryzm chain

### DIFF
--- a/cosmos/pryzm.json
+++ b/cosmos/pryzm.json
@@ -9,7 +9,8 @@
     "coinDenom": "PRYZM",
     "coinMinimalDenom": "upryzm",
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/pryzm/upryzm.png",
-    "coinDecimals": 6
+    "coinDecimals": 6,
+    "coinGeckoId": "pryzm"
   },
   "bip44": {
     "coinType": 118
@@ -27,7 +28,8 @@
       "coinDenom": "PRYZM",
       "coinMinimalDenom": "upryzm",
       "coinDecimals": 6,
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/pryzm/upryzm.png"
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/pryzm/upryzm.png",
+      "coinGeckoId": "pryzm"
     },
     {
       "coinDenom": "AUUU",
@@ -41,6 +43,7 @@
       "coinDenom": "PRYZM",
       "coinMinimalDenom": "upryzm",
       "coinDecimals": 6,
+      "coinGeckoId": "pryzm",
       "gasPriceStep": {
         "low": 0.02,
         "average": 0.03,

--- a/cosmos/pryzm.json
+++ b/cosmos/pryzm.json
@@ -38,6 +38,16 @@
   ],
   "feeCurrencies": [
     {
+      "coinDenom": "PRYZM",
+      "coinMinimalDenom": "upryzm",
+      "coinDecimals": 6,
+      "gasPriceStep": {
+        "low": 0.02,
+        "average": 0.03,
+        "high": 0.04
+      }
+    },
+    {
       "coinDenom": "AUUU",
       "coinMinimalDenom": "factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uauuu",
       "coinDecimals": 6,


### PR DESCRIPTION
This PR adds the PRYZM token to the list of fee currencies of Pryzm chain and also add the CoinGecko ID for PRYZM token.