### PR TITLE
feat: add mantra-dukong-legacy for account migration

### DIFF
--- a/cosmos/mantra-dukong-legacy.json
+++ b/cosmos/mantra-dukong-legacy.json
@@ -1,0 +1,52 @@
+{
+  "chainId": "mantra-dukong-1",
+  "chainName": "MANTRA Dukong Testnet",
+  "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/mantra-dukong/chain.png",
+  "rpc": "https://rpc.dukong.mantrachain.io",
+  "rest": "https://api.dukong.mantrachain.io",
+  "nodeProvider": {
+    "name": "MANTRA Chain Association",
+    "email": "security@mantrachain.io",
+    "website": "https://mantrachain.io/"
+  },
+  "bip44": {
+    "coinType": 118
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "mantra",
+    "bech32PrefixAccPub": "mantrapub",
+    "bech32PrefixValAddr": "mantravaloper",
+    "bech32PrefixValPub": "mantravaloperpub",
+    "bech32PrefixConsAddr": "mantravalcons",
+    "bech32PrefixConsPub": "mantravalconspub"
+  },
+  "currencies": [
+    {
+      "coinDenom": "OM",
+      "coinMinimalDenom": "uom",
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/mantra-dukong/om.png"
+    }
+  ],
+  "feeCurrencies": [
+    {
+      "coinDenom": "OM",
+      "coinMinimalDenom": "uom",
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/mantra-dukong/om.png",
+      "gasPriceStep": {
+        "low": 0.01,
+        "average": 0.025,
+        "high": 0.03
+      }
+    }
+  ],
+  "stakeCurrency": {
+    "coinDenom": "OM",
+    "coinMinimalDenom": "uom",
+    "coinDecimals": 6,
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/mantra-dukong/om.png"
+  },
+  "features": ["cosmwasm"],
+  "isTestnet": true
+}


### PR DESCRIPTION
Hello Keplr wallet team, I submit this PR and want to have a discussion with you.

MANTRA Chain is integrating EVM module, it's live on testnet and will go live to mainnet next month. As part of the integration, we want to help users to migrate their wallet address to coin type 60 with some eth features. 
Our migration solution would be a simple bank send from "legacy" address to new address, we are trying to minimize the user interaction to bring a smooth migration, so I created this `mantra-dukong-legacy.json` file. We hope we can add legacy address and new address at the same time with the same chain id, so that our frontend can read the 2 addresses and help them one-click migration.
<img width="2536" height="1802" alt="image" src="https://github.com/user-attachments/assets/5b07e112-f6e4-44c3-84f8-2c910abaa7e6" />

During our experiment, we notice that once the keplr-chain-registry is updated, MANTRA DuKong addresses are updated to coin type `60` and algo updated to `ethsecp256k1`, but seems it's not "fully" updated. "fully updated" means the wallet balance of `0x` address and `mantra1` address are the same, because the 2 address should be derive from the same private key, which makes them share the same entry in the bank module:

| Fully updated    | Half updated |
| -------- | ------- |
| <img width="680" height="300" alt="image" src="https://github.com/user-attachments/assets/49644d57-dcbb-46f8-ac4c-3027032edafc" />  | <img width="684" height="308" alt="image" src="https://github.com/user-attachments/assets/1c5e57ab-1c1e-439f-b6d2-1cad2a673f33" />    |

We need to manually remove the wallet and import the mnemonic to trigger the "fully updated".

Looking forward to your response!