### PR TITLE
fix(union-1): update coin gecko listing

### DIFF
--- a/cosmos/union.json
+++ b/cosmos/union.json
@@ -20,7 +20,7 @@
       "coinDenom": "U",
       "coinMinimalDenom": "au",
       "coinDecimals": 18,
-      "coinGeckoId": "union-2",
+      "coinGeckoId": "union",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union/chain.png"
     }
   ],
@@ -29,7 +29,7 @@
       "coinDenom": "U",
       "coinMinimalDenom": "au",
       "coinDecimals": 18,
-      "coinGeckoId": "union-2",
+      "coinGeckoId": "union",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union/chain.png",
       "gasPriceStep": {
         "low": 100000000,
@@ -42,7 +42,7 @@
     "coinDenom": "U",
     "coinMinimalDenom": "au",
     "coinDecimals": 18,
-    "coinGeckoId": "union-2",
+    "coinGeckoId": "union",
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/union/chain.png"
   },
   "features": ["cosmwasm"],


### PR DESCRIPTION
Coin Gecko ID changed from `union-2` to `union`

https://www.coingecko.com/en/coins/union