### PR TITLE
Add coinImageUrl for Paxi (paxi-mainnet)

### DIFF
--- a/cosmos/paxi-mainnet.json
+++ b/cosmos/paxi-mainnet.json
@@ -23,7 +23,8 @@
     {
       "coinDenom": "PAXI",
       "coinMinimalDenom": "upaxi",
-      "coinDecimals": 6
+      "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/paxi-mainnet/chain.png"
     }
   ],
   "feeCurrencies": [
@@ -31,13 +32,15 @@
       "coinDenom": "PAXI",
       "coinMinimalDenom": "upaxi",
       "coinDecimals": 6,
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/paxi-mainnet/chain.png",
       "gasPriceStep": { "low": 0.035, "average": 0.055, "high": 0.075 }
     }
   ],
   "stakeCurrency": {
     "coinDenom": "PAXI",
     "coinMinimalDenom": "upaxi",
-    "coinDecimals": 6
+    "coinDecimals": 6,
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/paxi-mainnet/chain.png"
   },
   "features": ["cosmwasm"],
   "isTestnet": false


### PR DESCRIPTION
Added coinImageUrl to cosmos/paxi-mainnet.json so that the PAXI token logo displays properly in Keplr.

Validated with:
yarn validate cosmos/paxi-mainnet.json