### PR TITLE
Provenance: Change gas price steps to 1nhash

### DIFF
--- a/cosmos/pio-mainnet.json
+++ b/cosmos/pio-mainnet.json
@@ -31,9 +31,9 @@
       "coinGeckoId": "hash-2",
       "coinMinimalDenom": "nhash",
       "gasPriceStep": {
-        "low": 3200,
-        "average": 3200,
-        "high": 3600
+        "low": 1,
+        "average": 1,
+        "high": 1
       }
     }
   ],


### PR DESCRIPTION
Provenance Blockchain v1.26.0 got an important network upgrade that changes how transaction fees work.

Update gas settings:
• Use 1nhash for gas prices (this is the new standard)
• Use a multiplier of 1.0 (or just leave it at default)
• If you don't update this, you'll end up overpaying on transaction fees
