### PR TITLE
hotfix(stoc): remove evm because of not having yet

### DIFF
--- a/cosmos/stoc.json
+++ b/cosmos/stoc.json
@@ -10,7 +10,7 @@
     "website": "https://www.stochain.io/"
   },
   "bip44": {
-    "coinType": 60
+    "coinType": 118
   },
   "bech32Config": {
     "bech32PrefixAccAddr": "stoc",
@@ -47,5 +47,5 @@
     "coinDecimals": 6,
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stoc/ustoc.png"
   },
-  "features": ["eth-address-gen", "eth-key-sign"]
+  "features": []
 }

--- a/cosmos/tstoc.json
+++ b/cosmos/tstoc.json
@@ -10,7 +10,7 @@
     "website": "https://www.stochain.io/"
   },
   "bip44": {
-    "coinType": 60
+    "coinType": 118
   },
   "bech32Config": {
     "bech32PrefixAccAddr": "stoc",
@@ -47,6 +47,6 @@
     "coinDecimals": 6,
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/tstoc/utstoc.png"
   },
-  "features": ["eth-address-gen", "eth-key-sign"],
+  "features": [],
   "isTestnet": true
 }


### PR DESCRIPTION
Hi, I create this hotfix because of wrong coinType. Sorry for the mistake