### PR TITLE
chore: update Korellia gas prices

### DIFF
--- a/cosmos/korellia.json
+++ b/cosmos/korellia.json
@@ -41,9 +41,9 @@
       "coinDecimals": 6,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/korellia/tkyve.png",
       "gasPriceStep": {
-        "low": 2,
-        "average": 3,
-        "high": 6
+        "low": 62.5,
+        "average": 80,
+        "high": 125
       }
     }
   ],


### PR DESCRIPTION
### Changes
In a recent [Korellia governance proposal](https://app.korellia.kyve.network/#/governance/466) the min gas prices was adjusted to 62.5. The values for low, average and high were updated accordingly.

Additional PRs for Kaon testnet and Mainnet might follow.

### Checklist
- [x] I have run `yarn validate <your-config-file>` locally, and it passed without any errors.
