### PR TITLE
feat: move Bostrom from native to non-native chain

### DIFF
--- a/cosmos/bostrom.json
+++ b/cosmos/bostrom.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://rpc-cyber.keplr.app",
-  "rest": "https://lcd-cyber.keplr.app",
+  "rpc": "https://rpc.bostrom.cybernode.ai",
+  "rest": "https://lcd.bostrom.cybernode.ai",
   "chainId": "bostrom",
   "chainName": "Bostrom",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/bostrom/chain.png",
@@ -11,8 +11,11 @@
     "coinGeckoId": "bostrom",
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/bostrom/boot.png"
   },
-  "walletUrl": "https://wallet.keplr.app/chains/bostrom",
-  "walletUrlForStaking": "https://wallet.keplr.app/chains/bostrom?modal=staking&chain=bostrom&step_id=2",
+  "nodeProvider": {
+    "name": "cybercongress",
+    "discord": "https://discord.gg/ARwv74ZyGH",
+    "website": "https://cyb.ai"
+  },
   "bip44": {
     "coinType": 118
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,6 @@ export const nativeMainnetChainIdentifiers: string[] = [
   "agoric",
   "akashnet",
   "axelar-dojo",
-  "bostrom",
   "core",
   "irishub",
   "kava_2222",


### PR DESCRIPTION
## Summary

- Remove `bostrom` from `nativeMainnetChainIdentifiers`
- Replace Keplr-hosted RPC/REST with cybercongress public endpoints
- Add `nodeProvider` (required for non-native chains)
- Remove `walletUrl` / `walletUrlForStaking`

KEPLR-2091