### PR TITLE
Fix MSTBL bech32 prefix (mstbl → wasm)

### DIFF
--- a/cosmos/mstbl.json
+++ b/cosmos/mstbl.json
@@ -13,14 +13,14 @@
   "bip44": {
     "coinType": 118
   },
-  "bech32Config": {
-    "bech32PrefixAccAddr": "mstbl",
-    "bech32PrefixAccPub": "mstblpub",
-    "bech32PrefixValAddr": "mstblvaloper",
-    "bech32PrefixValPub": "mstblvaloperpub",
-    "bech32PrefixConsAddr": "mstblvalcons",
-    "bech32PrefixConsPub": "mstblvalconspub"
-  },
+  ""bech32Config": {
+    "bech32PrefixAccAddr": "wasm",
+    "bech32PrefixAccPub": "wasmpub",
+    "bech32PrefixValAddr": "wasmvaloper",
+    "bech32PrefixValPub": "wasmvaloperpub",
+    "bech32PrefixConsAddr": "wasmvalcons",
+    "bech32PrefixConsPub": "wasmvalconspub"
+},
   "currencies": [
     {
       "coinDenom": "STAKE",

--- a/cosmos/mstbl.json
+++ b/cosmos/mstbl.json
@@ -13,7 +13,7 @@
   "bip44": {
     "coinType": 118
   },
-  ""bech32Config": {
+  "bech32Config": {
     "bech32PrefixAccAddr": "wasm",
     "bech32PrefixAccPub": "wasmpub",
     "bech32PrefixValAddr": "wasmvaloper",


### PR DESCRIPTION
### Changes
- Fix all bech32 prefixes from `mstbl*` to `wasm*`
- The MSTBL blockchain is built on wasmd and uses the `wasm` bech32 prefix
- Current config causes: "invalid Bech32 prefix; expected wasm, got mstbl"

### Verification
- RPC: https://rpc.stbl.mstbl.com/status
- REST: https://api.stbl.mstbl.com/cosmos/auth/v1beta1/accounts/wasm12mqjm7zgvmf30p53ktazn4pr7x5l765nlndzju