### PR TITLE
fix(epix): update wallet URL for staking to include hash fragment

### DIFF
--- a/cosmos/epix_1916.json
+++ b/cosmos/epix_1916.json
@@ -19,7 +19,7 @@
     "coinDecimals": 18,
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/epix_1916/chain.png"
   },
-  "walletUrlForStaking": "https://explorer.epix.zone/epix/staking",
+  "walletUrlForStaking": "https://explorer.epix.zone/#/staking",
   "bip44": {
     "coinType": 60
   },


### PR DESCRIPTION
This pull request makes a minor update to the `cosmos/epix_1916.json` configuration file, correcting the staking URL to use the proper hash route.

### Changes
- Updated the `walletUrlForStaking` field to use `https://explorer.epix.zone/#/staking` instead of the previous path-based URL.

### Checklist
- [x] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
- [x] I have run `yarn validate <your-config-file>` locally, and it passed without any errors.
