### PR TITLE
dungeon: update website to dungeongames.io and use Dungeon Games rpc/rest

### DIFF
--- a/cosmos/dungeon.json
+++ b/cosmos/dungeon.json
@@ -2,12 +2,12 @@
   "chainId": "dungeon-1",
   "chainName": "Dungeonchain",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dungeon/chain.png",
-  "rpc": "https://dungeon-wallet.rpc.quasarstaking.ai:443",
-  "rest": "https://dungeon-wallet.api.quasarstaking.ai",
+  "rpc": "https://rpc.dungeongames.io",
+  "rest": "https://api.dungeongames.io",
   "nodeProvider": {
     "name": "Crypto Dungeon",
     "email": "cryptodungeonma@gmail.com",
-    "website": "https://www.cryptodungeon.org/"
+    "website": "https://dungeongames.io"
   },
   "bip44": {
     "coinType": 118


### PR DESCRIPTION
## Summary
Maintenance update to the Dungeon Chain entry — submitted by the chain's operating team (Crypto Dungeon LLC).

**`cosmos/dungeon.json`:**
- `rpc`: `dungeon-wallet.rpc.quasarstaking.ai` → `https://rpc.dungeongames.io` (the team's own primary endpoint, already listed on cosmos/chain-registry)
- `rest`: `dungeon-wallet.api.quasarstaking.ai` → `https://api.dungeongames.io`
- `nodeProvider.website`: `cryptodungeon.org` → `https://dungeongames.io` (current canonical site)

A parallel cosmos/chain-registry PR mirrors this: https://github.com/cosmos/chain-registry/pull/7667