### PR TITLE
Update Gonka mainnet RPC/REST to public rpc.gonka.gg endpoints

### DIFF
--- a/cosmos/gonka-mainnet.json
+++ b/cosmos/gonka-mainnet.json
@@ -2,10 +2,10 @@
   "chainId": "gonka-mainnet",
   "chainName": "Gonka",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gonka-mainnet/chain.png",
-  "rpc": "https://gonka04.6block.com:8443/chain-rpc/",
-  "rest": "https://gonka04.6block.com:8443/chain-api/",
+  "rpc": "https://rpc.gonka.gg/key/keplr/chain-rpc/",
+  "rest": "https://rpc.gonka.gg/key/keplr/chain-api/",
   "nodeProvider": {
-    "name": "6block",
+    "name": "Gonka Labs",
     "email": "hello@productscience.ai",
     "website": "http://gonka.ai"
   },
@@ -34,9 +34,9 @@
       "coinMinimalDenom": "ngonka",
       "coinDecimals": 9,
       "gasPriceStep": {
-        "low": 0,
-        "average": 0,
-        "high": 0
+        "low": 1.5,
+        "average": 1.75,
+        "high": 2.0
       }
     }
   ],
@@ -49,6 +49,6 @@
     "cosmwasm"
   ],
   "explorers": {
-    "txPage": "https://gonka04.6block.com:8443/dashboard/gonka/txs/{txHash}"
+    "txPage": "https://gonka.gg/transactions/{txHash}"
   }
 }


### PR DESCRIPTION
### Changes
- Switch `rpc`/`rest` for Gonka mainnet from `https://gonka04.6block.com:8443` to the public, keyless HTTPS gateway `https://rpc.gonka.gg/key/keplr/{chain-rpc,chain-api}/` — fixes mixed-content blocking on HTTPS sites and gives all Keplr users a reliable public endpoint.
- Set `feeCurrencies[].gasPriceStep` to `1.5 / 1.75 / 2.0` (was `0 / 0 / 0`).
- Update `explorers.txPage` to `https://gonka.gg/transactions/{txHash}`.
- Update `nodeProvider.name` to `Gonka Labs`.

Verified against the registry validation rules: HTTPS endpoints (no `http://`), no query string in URLs, RPC `/status` reports `network: gonka-mainnet`, REST + tx simulate reachable, WebSocket upgrade returns `101`, valid TLS, and `gasPriceStep` satisfies `low ≤ average ≤ high`.

### Checklist
- [x] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
- [x] I have run `yarn validate cosmos/gonka-mainnet.json` locally, and it passed without any errors.
