### PR TITLE
Update Stargaze endpoints to Polkachu

### DIFF
--- a/cosmos/stargaze.json
+++ b/cosmos/stargaze.json
@@ -1,6 +1,11 @@
 {
-  "rpc": "https://rpc-stargaze.keplr.app",
-  "rest": "https://lcd-stargaze.keplr.app",
+  "rpc": "https://stargaze-rpc.polkachu.com",
+  "rest": "https://stargaze-api.polkachu.com",
+  "nodeProvider": {
+    "name": "Polkachu",
+    "email": "hello@polkachu.com",
+    "website": "https://polkachu.com/"
+  },
   "chainId": "stargaze-1",
   "chainName": "Stargaze",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stargaze/chain.png",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,6 @@ export const nativeMainnetChainIdentifiers: string[] = [
   "secret",
   "sentinelhub",
   "sommelier",
-  "stargaze",
   "stride",
   "crypto-org-chain-mainnet",
   "quicksilver",


### PR DESCRIPTION
## Summary
- Replace Stargaze RPC/REST endpoints with Polkachu public endpoints.
- Add Polkachu `nodeProvider` metadata for Stargaze.
- Remove `stargaze` from `nativeMainnetChainIdentifiers` so the registry validation treats the node provider metadata as required.

## Validation
- `yarn validate cosmos/stargaze.json`
- `yarn lint:test`
- Manually checked Polkachu RPC `/status` and REST `/cosmos/base/tendermint/v1beta1/blocks/latest` return `stargaze-1` latest block data.