### PR TITLE
Remove premature coinGeckoId from Lumera (LUME)

### DIFF
--- a/cosmos/lumera-mainnet.json
+++ b/cosmos/lumera-mainnet.json
@@ -9,7 +9,6 @@
     "coinDenom": "LUME",
     "coinMinimalDenom": "ulume",
     "coinDecimals": 6,
-    "coinGeckoId": "lumera",
     "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/lumera-mainnet/chain.png"
   },
   "bip44": {
@@ -28,7 +27,6 @@
       "coinDenom": "LUME",
       "coinMinimalDenom": "ulume",
       "coinDecimals": 6,
-      "coinGeckoId": "lumera",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/lumera-mainnet/chain.png"
     }
   ],
@@ -37,7 +35,6 @@
       "coinDenom": "LUME",
       "coinMinimalDenom": "ulume",
       "coinDecimals": 6,
-      "coinGeckoId": "lumera",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/lumera-mainnet/chain.png",
       "gasPriceStep": {
         "low": 0.025,


### PR DESCRIPTION
## What

Remove `coinGeckoId: "lumera"` from `cosmos/lumera-mainnet.json` (3 places: `stakeCurrency`, `currencies`, `feeCurrencies`).

## Why

LUME has **no market on CoinGecko or CoinMarketCap** — both show "price will be available soon" / $0 with zero trading volume and no listed exchanges. The CoinGecko `lumera` id is registered but returns an empty price object (`{"lumera":{}}`).

In Keplr, `CoinGeckoPriceStore.calculatePrice` falls back to `PricePretty(0).ready(false)` when the price is missing, which some UI surfaces render as a misleading **$0.00** next to users' LUME balances.

The id was added prematurely (2025-11) in anticipation of a listing that hasn't happened. Until LUME is actually listed and priced, showing no fiat value (token amount only) is more accurate than a fake $0.

## Effect

`calculatePrice` returns `undefined` (no `coinGeckoId`) → Keplr shows the LUME token amount with no fiat value, instead of $0.00.

## Note

When LUME gets listed on an exchange / DEX pool tracked by CoinGecko, re-add `coinGeckoId: "lumera"` (the id itself is correct) and the price will populate automatically.
