### PR TITLE
Fix PR changed files validation

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -4,6 +4,10 @@ on:
     types: [opened, synchronize]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validation:
     name: Pull Request Suggest Chain Validation
@@ -25,8 +29,9 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v34
+        uses: step-security/changed-files@v47.0.5
         with:
+          use_rest_api: true
           files: |
             cosmos/**
             evm/**
@@ -35,8 +40,8 @@ jobs:
       - name: Validate changed files
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            if [[ $file == *".json"* ]]; then
-              yarn ts-node src/index.ts $file
+            if [[ "$file" == *".json"* ]]; then
+              yarn ts-node src/index.ts "$file"
             fi
           done
         env:


### PR DESCRIPTION
## Summary
- replace the old changed-files action with step-security/changed-files
- force REST API mode so validation uses the pull request file list instead of merge-commit git diff inference
- add explicit pull-requests: read permission and quote validated file paths

## Root Cause
The previous workflow let the changed-files action infer changes from the checked-out git state. For stale PR branches, this could include files changed on the base branch after the PR branch diverged, causing unrelated chain JSON files to be validated.

## Validation
- git diff --check
- pre-commit formatting check during commit
- confirmed PR #1468 only reports cosmos/bitcanna.json via `gh pr diff 1468 --name-only`
