### PR TITLE
Update Dungeon (dungeon-1) RPC/REST — registered endpoint is stuck/stale

### DIFF
--- a/cosmos/dungeon.json
+++ b/cosmos/dungeon.json
@@ -2,8 +2,8 @@
   "chainId": "dungeon-1",
   "chainName": "Dungeonchain",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dungeon/chain.png",
-  "rpc": "https://dungeon-wallet.rpc.quasarstaking.ai:443",
-  "rest": "https://dungeon-wallet.api.quasarstaking.ai",
+  "rpc": "https://rpc.dungeongames.io",
+  "rest": "https://api.dungeongames.io",
   "nodeProvider": {
     "name": "Crypto Dungeon",
     "email": "cryptodungeonma@gmail.com",

--- a/cosmos/dungeon.json
+++ b/cosmos/dungeon.json
@@ -39,7 +39,8 @@
         "average": 0.07,
         "high": 0.09
       },
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dungeon/chain.png"
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/dungeon/chain.png",
+      "coinGeckoId": "dragon-coin-2"
     }
   ],
   "stakeCurrency": {


### PR DESCRIPTION
## What
Updates the `rpc` and `rest` for **dungeon-1** in `cosmos/dungeon.json` to the chain's own current endpoints.

## Why
The currently-registered `dungeon-wallet.rpc.quasarstaking.ai` is **stuck/stale** — it reports `catching_up: false` at height **16,582,601** while the live chain is at **~16,668,300** (~85k blocks behind), and connections intermittently fail. Keplr therefore reads a stale account sequence and broadcasts to a dead node, so dungeon-1 transactions (claim, send, stake) fail.

## Change
- `rpc`: `https://dungeon-wallet.rpc.quasarstaking.ai:443` → `https://rpc.dungeongames.io`
- `rest`: `https://dungeon-wallet.api.quasarstaking.ai` → `https://api.dungeongames.io`

Both are the chain's official public nodes, verified live (HTTP 200, `network: dungeon-1`, current height). Fees and all other fields unchanged.