### PR TITLE
update gas price for hippo protocol

### DIFF
--- a/cosmos/hippo-protocol.json
+++ b/cosmos/hippo-protocol.json
@@ -35,9 +35,9 @@
       "coinDecimals": 18,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/hippo-protocol/chain.png",
       "gasPriceStep": {
-        "low": 500000000000,
-        "average": 600000000000,
-        "high": 1000000000000
+        "low": 5000000000000,
+        "average": 6000000000000,
+        "high": 10000000000000
       }
     }
   ],


### PR DESCRIPTION
### Changes
- change min gas price from 500000000000ahp to 5000000000000ahp
- ref. https://river.hippoprotocol.ai/hippoprotocol/gov/28

### Checklist
- [x] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
- [x] I have run `yarn validate <your-config-file>` locally, and it passed without any errors.
