### PR TITLE
fix/correct gas prices

### DIFF
--- a/cosmos/blockmaze_6162.json
+++ b/cosmos/blockmaze_6162.json
@@ -46,9 +46,9 @@
       "coinDecimals": 18,
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/blockmaze_6162/bmz.png",
       "gasPriceStep": {
-        "low": 1000000000,
-        "average": 1500000000,
-        "high": 2000000000
+        "low": 150000000000,
+        "average": 175000000000,
+        "high": 200000000000
       }
     }
   ],


### PR DESCRIPTION
### Changes

* Updated the BMZ `gasPriceStep` values to align with the chain's configured fee market `min_gas_price`.
* Increased the low gas price from `1 gwei` to `150 gwei`.
* Updated the average and high gas price values to ensure transactions submitted through Keplr meet the chain's minimum gas price requirements.
* Fixes transaction failures caused by insufficient gas prices.

### Checklist

* [x] I have read and followed the contribution guideline.
* [x] I have run `yarn validate cosmos/blockmaze_6162.json` locally, and it passed without any errors.
