### PR TITLE
Update Ethwei Testnet node provider website

### DIFF
--- a/cosmos/ethwei-testnet.json
+++ b/cosmos/ethwei-testnet.json
@@ -4,7 +4,7 @@
   "nodeProvider": {
     "name": "CyphCube",
     "email": "info@cyphcube.com",
-    "website": "https://ethwei.com"
+    "website": "https://cyphcube.com"
   },
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/ethwei-testnet/chain.png",
   "rpc": "https://rpc-testnet.ethwei.com",


### PR DESCRIPTION
Updates the `nodeProvider.website` for **Ethwei Testnet** (`ethwei-testnet-1`) from
`https://ethwei.com` to `https://cyphcube.com` (the node provider's own site).

Single-field change to `cosmos/ethwei-testnet.json`. `yarn validate cosmos/ethwei-testnet.json`
passes locally (RPC WebSocket + REST connectivity, schema).