### PR TITLE
Update Blockmaze Testnet V2 endpoints for EVM and Cosmos

### DIFF
--- a/cosmos/blockmaze_6162.json
+++ b/cosmos/blockmaze_6162.json
@@ -1,11 +1,11 @@
 {
-  "rpc": "https://v2-tendermint.testnet.stackflow.site",
-  "rest": "https://v2-bm-api.testnet.stackflow.site",
+  "rpc": "https://testnet-tendermint.blockmaze.com",
+  "rest": "https://testnet-bm-api.blockmaze.com",
   "chainId": "blockmaze_6162-1",
   "chainName": "Blockmaze Testnet V2",
   "evm": {
     "chainId": 6162,
-    "rpc": "https://v2-evm-rpc.testnet.stackflow.site"
+    "rpc": "https://testnet-evm-rpc.blockmaze.com"
   },
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/blockmaze_6162/chain.png",
   "walletUrlForStaking": "https://delegator.testnet.stackflow.site",

--- a/evm/eip155:6162.json
+++ b/evm/eip155:6162.json
@@ -1,6 +1,6 @@
 {
-  "rpc": "https://v2-evm-rpc.testnet.stackflow.site",
-  "websocket": "wss://v2-evm-rpc.testnet.stackflow.site",
+  "rpc": "https://testnet-evm-rpc.blockmaze.com",
+  "websocket": "wss://testnet-evm-ws.blockmaze.com",
   "chainId": "eip155:6162",
   "chainName": "Blockmaze Testnet V2 (EVM)",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/eip155:6162/chain.png",
@@ -36,6 +36,6 @@
   "features": [],
   "isTestnet": true,
   "explorers": {
-    "txPage": "https://explorer.testnet.stackflow.site/evm/tx/{txHash}"
+    "txPage": "https://testnet-explorer.bmzscan.com/evm/tx/{txHash}"
   }
 }


### PR DESCRIPTION
### Changes
- Updated Tendermint RPC and REST/API endpoints to use the new `blockmaze.com` domains in `cosmos/blockmaze_6162.json`.
- Updated EVM RPC, websocket, and explorer txPage endpoints in `cosmos/blockmaze_6162.json` and `evm/eip155:6162.json` to use the new domains.

### Checklist
- [x] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
