### PR TITLE
fix(ritbit-mainnet): raise RIT gasPriceStep to the chain minimum

### DIFF
--- a/cosmos/ritbit-mainnet.json
+++ b/cosmos/ritbit-mainnet.json
@@ -46,9 +46,9 @@
       "coinMinimalDenom": "urit",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/ritbit-mainnet/chain.png",
       "gasPriceStep": {
-        "low": 12500000000,
-        "average": 12500000000,
-        "high": 20000000000
+        "low": 25000000000,
+        "average": 30000000000,
+        "high": 40000000000
       }
     },
     {


### PR DESCRIPTION
The RIT `gasPriceStep` for `ritbit-mainnet` is below what the chain accepts, so **every** transaction paying fees in RIT is rejected with `insufficient fees` — the `high` step included.

The node advertises:

```
minimum-gas-prices = "0.025uusdc,25000000000urit"
```

Registry currently has:

| step | current | required |
|---|---|---|
| low | 12500000000 | 25000000000 |
| average | 12500000000 | — |
| high | 20000000000 | — |

All three are under the minimum; `low` and `average` are exactly half of it.

This PR sets `low` to the minimum and puts `average`/`high` above it so a congested block does not strand the transaction. The USDC fee currency (`0.025uusdc`) already matched the chain and is left untouched.

Verified against a mainnet node today.