### PR TITLE
Fix Axiome gasPriceStep (sends fail with insufficient fee)

### DIFF
--- a/cosmos/axiome.json
+++ b/cosmos/axiome.json
@@ -42,9 +42,9 @@
       "coinGeckoId": "axiome",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/axiome/uaxm.png",
       "gasPriceStep": {
-        "low": 0.05,
-        "average": 0.1,
-        "high": 0.25
+        "low": 1,
+        "average": 1.65,
+        "high": 7.4
       }
     }
   ],


### PR DESCRIPTION
### Changes
Corrects `gasPriceStep` for Axiome. The values merged in #1538 (0.05 / 0.1 / 0.25) are below what the chain's public LCD actually enforces, so **every send from Keplr fails**.

### Evidence
Broadcasting a `MsgSend` (gas limit 200000) through the LCD declared in the config:

| gas price | result |
|---|---|
| 0.05 | `code 13: insufficient fees; got: 10000uaxm required: 200000uaxm` |
| 0.25 | rejected, same error |
| 0.5 | rejected, same error |
| **1.0** | accepted (proceeds to signature verification) |

The enforced minimum on that endpoint is **1.0 uaxm/gas**. Keplr defaults to the average step, which was 0.1, so sends were rejected before reaching the mempool.

Note the minimum is node dependent: some RPC nodes accept 0.05, which is why the original figure looked correct when sampling on-chain transactions. The value has to satisfy the endpoint published in this registry.

### New values
- `low` 1.0, the enforced minimum
- `average` 1.65, the median gas price observed on chain
- `high` 7.4, what the native Axiome wallet pays

Fees stay tiny in fiat terms (a transfer costs well under a cent at current AXM price).