### PR TITLE
fix(dymension): move txPage off dym.fyi before it shuts down

### DIFF
--- a/cosmos/dymension_1100.json
+++ b/cosmos/dymension_1100.json
@@ -55,6 +55,6 @@
     "eth-key-sign"
   ],
   "explorers": {
-    "txPage": "https://dym.fyi/tx/{txHash:uppercase}"
+    "txPage": "https://dymension.explorers.guru/transaction/{txHash}"
   }
 }


### PR DESCRIPTION
## Problem

`dym.fyi` is going away. The explorer now serves a shutdown notice:

> NextBE has been forced into insolvency and will permanently shut down all Dymension Block Explorer nodes, indexing APIs, and support on August 25, 2026.

After that date every Dymension tx link in Keplr points at a dead explorer.

## Change

`cosmos/dymension_1100.json` — `explorers.txPage` now points at Explorers.Guru:

```diff
-    "txPage": "https://dym.fyi/tx/{txHash:uppercase}"
+    "txPage": "https://dymension.explorers.guru/transaction/{txHash}"
```

Verified live against real chain data (`/transaction/{hash}`, `/account/{address}`, `/validator/{address}` all resolve; bogus inputs 404, so it is a real backend and not an SPA catch-all). Path pattern matches the existing `lava`, `nibiru` and `paloma` entries in this registry.

The `:uppercase` modifier was a dym.fyi requirement and is dropped — Explorers.Guru resolves the hash in either case.

Mintscan was considered and rejected: `cosmostation/chainlist` lists Dym.Fyi as Dymension's explorer, and `mintscan.io/dymension` only 200s because the SPA returns 200 for any unknown chain path.