### PR TITLE
Update gnodi.json

### DIFF
--- a/cosmos/gnodi.json
+++ b/cosmos/gnodi.json
@@ -2,12 +2,12 @@
   "chainId": "gnodi",
   "chainName": "Gnodi",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/gnodi/gnod.png",
-  "rpc": "https://rpc.gnodi.zone",
-  "rest": "https://api.gnodi.zone",
+  "rpc": "https://rpc.gnodipowered.com",
+  "rest": "https://api.gnodipowered.com",
   "nodeProvider": {
-    "name": "Gnodi Team",
-    "email": "info@gnodiblockchain.org",
-    "website": "https://gnodiblockchain.org"
+    "name": "Gnodi Powered",
+    "email": "support@blockreign.tech",
+    "website": "https://gnodipowered.com/"
   },
   "bip44": {
     "coinType": 118
@@ -44,5 +44,8 @@
     "coinDenom": "GNOD",
     "coinMinimalDenom": "uGNOD",
     "coinDecimals": 6
+  },
+  "explorers": {
+    "txPage": "https://gnodiscanner.com/txs/{txHash}"
   }
 }


### PR DESCRIPTION
cosmos/gnodi.json is updated and passes yarn validate (exit 0).

  Changes: RPC/REST moved to the gnodipowered endpoints, nodeProvider updated to Gnodi Powered /
  support@blockreign.tech / https://gnodipowered.com/, and added explorers.txPage →
  https://gnodiscanner.com/txs/{txHash} (verified GnodiScan's API resolves both upper- and lowercase hashes,
  so Keplr's default uppercase {txHash} is safe).

  The validator does live checks, all of which passed: CometBFT WebSocket handshake against the RPC, chainId
  match on both RPC and LCD, and the 256×256 PNG check on images/gnodi/gnod.png.

### Changes
- 

### Checklist
- [x ] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
- [ x] I have run `yarn validate <your-config-file>` locally, and it passed without any errors.
