### PR TITLE
chore(mocha): update Celestia Mocha testnet chainId to mocha-5

### DIFF
--- a/cosmos/mocha.json
+++ b/cosmos/mocha.json
@@ -1,7 +1,7 @@
 {
   "rpc": "https://rpc-1.testnet.celestia.nodes.guru",
   "rest": "https://api-1.testnet.celestia.nodes.guru",
-  "chainId": "mocha-4",
+  "chainId": "mocha-5",
   "chainName": "Celestia Mocha Testnet",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/mocha/chain.png",
   "stakeCurrency": {


### PR DESCRIPTION
Celestia's Mocha testnet has restarted as a new chain, `mocha-5`. This updates `cosmos/mocha.json` so Keplr points at the live chain.

### Context

`mocha-5` is not an in-place upgrade — it is a hardspoon of `mocha-4` at block [13205115](https://celestia.explorers.guru/block/13205115), started from a new genesis at height 1. `mocha-4` remains running until it is shut down on **September 1, 2026**, so the registry entry needs to move before then.

Reference: https://docs.celestia.org/operate/networks/mocha-testnet/

### Change

Only `chainId` changes, from `mocha-4` to `mocha-5`. The registered RPC and REST endpoints already serve the new chain, so no endpoint changes are needed.

### Verification

Per the checklist in the README:

- **chainId matches the RPC node** — `https://rpc-1.testnet.celestia.nodes.guru/status` reports `node_info.network = "mocha-5"`
- **chainId matches the REST node** — `https://api-1.testnet.celestia.nodes.guru/cosmos/base/tendermint/v1beta1/blocks/latest` returns `chain_id: "mocha-5"`
- **Both nodes are healthy** — both responded and are advancing (height ~65600 at the time of writing; `mocha-5` restarted at height 1)
- **Websocket is open** — `https://rpc-1.testnet.celestia.nodes.guru/websocket` completes the upgrade handshake with `HTTP/1.1 101 Switching Protocols`
- **Validator passes** — `yarn validate cosmos/mocha.json` exits 0

No gas price, denom, bech32, or image changes are included.
