### PR TITLE
feat: enable native tx history for Gonka (gonka-mainnet)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const nativeMainnetChainIdentifiers: string[] = [
   "lumera-mainnet",
   "zigchain",
   "pio-mainnet",
+  "gonka-mainnet",
   "eip155:1",
   "eip155:10",
   "eip155:56",


### PR DESCRIPTION
## Summary

- Promote `gonka-mainnet` to `nativeMainnetChainIdentifiers` so Keplr Mobile / Extension stop showing **“Non-native chains not supported”** on the GNK asset screen and can render Activity / token-detail history.
- Explorer tx links are already configured: `https://gonka.gg/transactions/{txHash}`

## Backend follow-up (Keplr)

Native listing is necessary but not sufficient. Please also index `gonka-mainnet` on the tx-history backend (`/tx-history/supports`).

| Field | Value |
| --- | --- |
| chainId | `gonka-mainnet` |
| coin type | `1200` |
| bech32 | `gonka` |
| native denom | `ngonka` |
| RPC | `https://rpc.gonka.gg/key/keplr/chain-rpc/` |
| REST | `https://rpc.gonka.gg/key/keplr/chain-api/` |
| Explorer | https://gonka.gg/transactions/{txHash} |

## Test plan

- [ ] GNK on Gonka no longer shows “Non-native chains not supported”
- [ ] Recent sends/receives appear
- [ ] Tapping a tx opens `https://gonka.gg/transactions/<hash>`