### PR TITLE
Add TWIX staking metadata

### DIFF
--- a/cosmos/twix.json
+++ b/cosmos/twix.json
@@ -32,6 +32,12 @@
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/twix/chain.png"
     }
   ],
+  "stakeCurrency": {
+    "coinDenom": "TWIX",
+    "coinMinimalDenom": "atwix",
+    "coinDecimals": 18,
+    "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/twix/chain.png"
+  },
   "feeCurrencies": [
     {
       "coinDenom": "TWIX",


### PR DESCRIPTION
## Add verified TWIX staking metadata

Adds `stakeCurrency` for TWIX Mainnet now that the live mainnet staking configuration has been verified.

The original TWIX submission intentionally omitted this field until the bond denom could be confirmed directly from the running mainnet. The live staking API now reports:

- Bond denom: `atwix`
- Native staking asset: `TWIX`
- Decimals: `18`
- Unbonding period: `1814400s` (21 days)
- Bonded validator endpoint is live and returning the TWIX Genesis Validator
- Distribution parameters endpoint is live

Sorry I didn't include this with the original submission — I wanted to verify the live staking data rather than guess at it.

And @KamaIOps, hope you're feeling better. Thanks again for taking the time to get TWIX through the initial review and merge.