### PR TITLE
feat(zigchain): add gasPriceStep to zig-test-2 fee currency

### DIFF
--- a/cosmos/zig-test.json
+++ b/cosmos/zig-test.json
@@ -39,7 +39,12 @@
       "coinDenom": "ZIG",
       "coinMinimalDenom": "azig",
       "coinDecimals": 18,
-      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/zig-test/azig.png"
+      "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/zig-test/azig.png",
+      "gasPriceStep": {
+        "low": 2500000000,
+        "average": 25000000000,
+        "high": 50000000000
+      }
     }
   ],
   "stakeCurrency": {


### PR DESCRIPTION
Scales gas prices by 1e12 to match the testnet's azig 18-decimal base unit. The low step equals the value the zig-test-2 node already reports as its minimum_gas_price.

### Changes
- 

### Checklist
- [ ] I have read and followed the [contribution guideline](https://github.com/chainapsis/keplr-chain-registry/blob/main/README.md).
- [ ] I have run `yarn validate <your-config-file>` locally, and it passed without any errors.
